### PR TITLE
Update licences

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ Use of libraries under the terms of the LGPLv3 is via the
 |---------------|----------------------------------------------------------------------------------------------------------|
 | cairo         | Mozilla Public License 2.0                                                                               |
 | expat         | MIT Licence                                                                                              |
-| fontconfig    | [fontconfig Licence](https://cgit.freedesktop.org/fontconfig/tree/COPYING) (BSD-like)                    |
-| freetype      | [freetype Licence](http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/FTL.TXT) (BSD-like) |
+| fontconfig    | [fontconfig Licence](https://gitlab.freedesktop.org/fontconfig/fontconfig/blob/master/COPYING) (BSD-like)|
+| freetype      | [freetype Licence](https://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/FTL.TXT) (BSD-like)|
 | fribidi       | LGPLv3                                                                                                   |
+| gdk-pixbuf    | LGPLv3                                                                                                   |
 | gettext       | LGPLv3                                                                                                   |
 | giflib        | MIT Licence                                                                                              |
 | glib          | LGPLv3                                                                                                   |
@@ -65,11 +66,11 @@ Use of libraries under the terms of the LGPLv3 is via the
 | libjpeg-turbo | [zlib License, IJG License](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/LICENSE.md)       |
 | libpng        | [libpng License](http://www.libpng.org/pub/png/src/libpng-LICENSE.txt)                                   |
 | librsvg       | LGPLv3                                                                                                   |
-| libtiff       | [libtiff License](http://www.libtiff.org/misc.html) (BSD-like)                                           |
-| libuuid       | New BSD License                                                                                          |
+| libtiff       | [libtiff License](https://libtiff.gitlab.io/libtiff/misc.html) (BSD-like)                                |
 | libvips       | LGPLv3                                                                                                   |
 | libwebp       | New BSD License                                                                                          |
 | libxml2       | MIT Licence                                                                                              |
+| orc           | [orc License](https://gitlab.freedesktop.org/gstreamer/orc/blob/master/COPYING) (BSD-like)               |
 | pango         | LGPLv3                                                                                                   |
 | pixman        | MIT Licence                                                                                              |
 | zlib          | [zlib Licence](https://github.com/madler/zlib/blob/master/zlib.h)                                        |

--- a/README.md
+++ b/README.md
@@ -46,31 +46,31 @@ all of which are compatible with the Apache 2.0 Licence.
 Use of libraries under the terms of the LGPLv3 is via the
 "any later version" clause of the LGPLv2 or LGPLv2.1.
 
-| Library       | Used under the terms of                                                                                  |
-|---------------|----------------------------------------------------------------------------------------------------------|
-| cairo         | Mozilla Public License 2.0                                                                               |
-| expat         | MIT Licence                                                                                              |
-| fontconfig    | [fontconfig Licence](https://gitlab.freedesktop.org/fontconfig/fontconfig/blob/master/COPYING) (BSD-like)|
-| freetype      | [freetype Licence](https://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/FTL.TXT) (BSD-like)|
-| fribidi       | LGPLv3                                                                                                   |
-| gdk-pixbuf    | LGPLv3                                                                                                   |
-| gettext       | LGPLv3                                                                                                   |
-| giflib        | MIT Licence                                                                                              |
-| glib          | LGPLv3                                                                                                   |
-| harfbuzz      | MIT Licence                                                                                              |
-| lcms          | MIT Licence                                                                                              |
-| libcroco      | LGPLv3 (Windows only)                                                                                    |
-| libexif       | LGPLv3                                                                                                   |
-| libffi        | MIT Licence                                                                                              |
-| libgsf        | LGPLv3                                                                                                   |
-| libjpeg-turbo | [zlib License, IJG License](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/LICENSE.md)       |
-| libpng        | [libpng License](http://www.libpng.org/pub/png/src/libpng-LICENSE.txt)                                   |
-| librsvg       | LGPLv3                                                                                                   |
-| libtiff       | [libtiff License](https://libtiff.gitlab.io/libtiff/misc.html) (BSD-like)                                |
-| libvips       | LGPLv3                                                                                                   |
-| libwebp       | New BSD License                                                                                          |
-| libxml2       | MIT Licence                                                                                              |
-| orc           | [orc License](https://gitlab.freedesktop.org/gstreamer/orc/blob/master/COPYING) (BSD-like)               |
-| pango         | LGPLv3                                                                                                   |
-| pixman        | MIT Licence                                                                                              |
-| zlib          | [zlib Licence](https://github.com/madler/zlib/blob/master/zlib.h)                                        |
+| Library       | Used under the terms of                                                                                   |
+|---------------|-----------------------------------------------------------------------------------------------------------|
+| cairo         | Mozilla Public License 2.0                                                                                |
+| expat         | MIT Licence                                                                                               |
+| fontconfig    | [fontconfig Licence](https://gitlab.freedesktop.org/fontconfig/fontconfig/blob/master/COPYING) (BSD-like) |
+| freetype      | [freetype Licence](https://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/FTL.TXT) (BSD-like) |
+| fribidi       | LGPLv3                                                                                                    |
+| gdk-pixbuf    | LGPLv3                                                                                                    |
+| gettext       | LGPLv3                                                                                                    |
+| giflib        | MIT Licence                                                                                               |
+| glib          | LGPLv3                                                                                                    |
+| harfbuzz      | MIT Licence                                                                                               |
+| lcms          | MIT Licence                                                                                               |
+| libcroco      | LGPLv3 (Windows only)                                                                                     |
+| libexif       | LGPLv3                                                                                                    |
+| libffi        | MIT Licence                                                                                               |
+| libgsf        | LGPLv3                                                                                                    |
+| libjpeg-turbo | [zlib License, IJG License](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/LICENSE.md)        |
+| libpng        | [libpng License](http://www.libpng.org/pub/png/src/libpng-LICENSE.txt)                                    |
+| librsvg       | LGPLv3                                                                                                    |
+| libtiff       | [libtiff License](https://libtiff.gitlab.io/libtiff/misc.html) (BSD-like)                                 |
+| libvips       | LGPLv3                                                                                                    |
+| libwebp       | New BSD License                                                                                           |
+| libxml2       | MIT Licence                                                                                               |
+| orc           | [orc License](https://gitlab.freedesktop.org/gstreamer/orc/blob/master/COPYING) (BSD-like)                |
+| pango         | LGPLv3                                                                                                    |
+| pixman        | MIT Licence                                                                                               |
+| zlib          | [zlib Licence](https://github.com/madler/zlib/blob/master/zlib.h)                                         |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Use of libraries under the terms of the LGPLv3 is via the
 | glib          | LGPLv3                                                                                                    |
 | harfbuzz      | MIT Licence                                                                                               |
 | lcms          | MIT Licence                                                                                               |
-| libcroco      | LGPLv3 (Windows only)                                                                                     |
+| libcroco      | LGPLv3 (Windows / macOS only)                                                                             |
 | libexif       | LGPLv3                                                                                                    |
 | libffi        | MIT Licence                                                                                               |
 | libgsf        | LGPLv3                                                                                                    |


### PR DESCRIPTION
This PR adds the following licences that were missing:
- gdk-pixbuf - LGPLv2.1;
- orc - [orc License](https://gitlab.freedesktop.org/gstreamer/orc/blob/master/COPYING) (BSD-like) 
   (could also be changed to this SPDX identifier: `BSD-2-Clause AND BSD-3-Clause`, [see discussion](https://github.com/conda-forge/gstreamer-orc-feedstock/pull/4/files/96bfda04d089eb224da66b1ab63179a5c79e6f50#r353797464))

And removes the license for libuuid, as it is no longer required by fontconfig. I've also updated a couple of URLs to a more secure variant.

For easier reviewing, I've made the column width change in a separate commit.
