### PR TITLE
Add Brotli-compressed release tarballs #43

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -46,20 +46,31 @@ jobs:
     - name: Install dependencies (macOS)
       run: |
         pip3 install meson ninja
-        brew install advancecomp automake nasm pkg-config
+        brew install advancecomp automake brotli nasm pkg-config
       if: matrix.platform == 'darwin-x64'
     - name: Build ${{ matrix.platform }}
       id: build-release
       run: |
         ./build.sh $(cat LIBVIPS_VERSION) ${{ matrix.platform }}
-        echo "::set-output name=asset_file_name::libvips-$(cat LIBVIPS_VERSION)-${{ matrix.platform }}.tar.gz"
-    - name: Upload Release Asset
+        echo "::set-output name=asset_file_name_gz::libvips-$(cat LIBVIPS_VERSION)-${{ matrix.platform }}.tar.gz"
+        echo "::set-output name=asset_file_name_br::libvips-$(cat LIBVIPS_VERSION)-${{ matrix.platform }}.tar.br"
+    - name: Upload Release Asset (.tar.gz)
       id: upload-release-asset
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create-release.outputs.upload_url }}
-        asset_path: ${{ steps.build-release.outputs.asset_file_name }}
-        asset_name: ${{ steps.build-release.outputs.asset_file_name }}
+        asset_path: ${{ steps.build-release.outputs.asset_file_name_gz }}
+        asset_name: ${{ steps.build-release.outputs.asset_file_name_gz }}
         asset_content_type: application/gzip
+    - name: Upload Release Asset (.tar.br)
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ env.upload_url }}
+        asset_path: ${{ steps.build-release.outputs.asset_file_name_br }}
+        asset_name: ${{ steps.build-release.outputs.asset_file_name_br }}
+        asset_content_type: application/x-brotli

--- a/build.sh
+++ b/build.sh
@@ -80,4 +80,4 @@ for flavour in linux-x64 linuxmusl-x64 linux-armv6 linux-armv7 linux-arm64v8; do
 done
 
 # Display checksums
-sha256sum *.tar.gz
+sha256sum *.tar.{br,gz}

--- a/build/lin.sh
+++ b/build/lin.sh
@@ -431,4 +431,12 @@ tar chzf ${PACKAGE}/libvips-${VERSION_VIPS}-${PLATFORM}.tar.gz \
   lib \
   *.json \
   THIRD-PARTY-NOTICES.md
+
+# Recompress using AdvanceCOMP, ~5% smaller
 advdef --recompress --shrink-insane ${PACKAGE}/libvips-${VERSION_VIPS}-${PLATFORM}.tar.gz
+
+# Recompress using Brotli, ~15% smaller
+gunzip -c ${PACKAGE}/libvips-${VERSION_VIPS}-${PLATFORM}.tar.gz | brotli -o ${PACKAGE}/libvips-${VERSION_VIPS}-${PLATFORM}.tar.br
+
+# Allow tarballs to be read outside container
+chmod 644 ${PACKAGE}/libvips-${VERSION_VIPS}-${PLATFORM}.tar.*

--- a/build/win.sh
+++ b/build/win.sh
@@ -31,8 +31,15 @@ tar czf /packaging/libvips-${VERSION_VIPS}-${PLATFORM}.tar.gz \
   lib/*.dll \
   *.json \
   THIRD-PARTY-NOTICES.md
-echo "Shrinking tarball"
+
+# Recompress using AdvanceCOMP, ~5% smaller
 advdef --recompress --shrink-insane /packaging/libvips-${VERSION_VIPS}-${PLATFORM}.tar.gz
+
+# Recompress using Brotli, ~15% smaller
+gunzip -c /packaging/libvips-${VERSION_VIPS}-${PLATFORM}.tar.gz | brotli -o /packaging/libvips-${VERSION_VIPS}-${PLATFORM}.tar.br
+
+# Allow tarballs to be read outside container
+chmod 644 /packaging/libvips-${VERSION_VIPS}-${PLATFORM}.tar.*
 
 # Remove working directories
 rm -rf lib include *.json THIRD-PARTY-NOTICES.md

--- a/linux-arm64v8/Dockerfile
+++ b/linux-arm64v8/Dockerfile
@@ -13,6 +13,7 @@ RUN \
     advancecomp \
     autoconf \
     autopoint \
+    brotli \
     cmake \
     crossbuild-essential-arm64 \
     gettext \

--- a/linux-armv6/Dockerfile
+++ b/linux-armv6/Dockerfile
@@ -13,6 +13,7 @@ RUN \
     advancecomp \
     autoconf \
     autopoint \
+    brotli \
     cmake \
     gettext \
     git \

--- a/linux-armv7/Dockerfile
+++ b/linux-armv7/Dockerfile
@@ -13,6 +13,7 @@ RUN \
     advancecomp \
     autoconf \
     autopoint \
+    brotli \
     cmake \
     crossbuild-essential-armhf \
     gettext \

--- a/linux-x64/Dockerfile
+++ b/linux-x64/Dockerfile
@@ -10,6 +10,7 @@ RUN \
   yum group install -y "Development Tools" && \
   yum install -y --setopt=tsflags=nodocs \
     advancecomp \
+    brotli \
     cmake3 \
     devtoolset-8-gcc \
     devtoolset-8-gcc-c++ \

--- a/linuxmusl-x64/Dockerfile
+++ b/linuxmusl-x64/Dockerfile
@@ -10,6 +10,7 @@ RUN \
     autoconf \
     automake \
     binutils \
+    brotli \
     build-base \
     cmake \
     curl \

--- a/win32-ia32/Dockerfile
+++ b/win32-ia32/Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Lovell Fuller <npm@lovell.info>"
 
 # Create Debian-based container suitable for post-processing 32-bit Windows binaries
 
-RUN apt-get update && apt-get install -y curl zip advancecomp
+RUN apt-get update && apt-get install -y advancecomp brotli curl zip
 
 ENV PLATFORM="win32-ia32"

--- a/win32-x64/Dockerfile
+++ b/win32-x64/Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Lovell Fuller <npm@lovell.info>"
 
 # Create Debian-based container suitable for post-processing 64-bit Windows binaries
 
-RUN apt-get update && apt-get install -y curl zip advancecomp
+RUN apt-get update && apt-get install -y advancecomp brotli curl zip
 
 ENV PLATFORM="win32-x64"


### PR DESCRIPTION
This will provide .tar.br files alongside the existing .tar.gz files for a given release. See #43 for more context.

@kleisauke Would net-vips benefit from these? We could also consider providing .tar.xz variants too.