### PR TITLE
Include libspng as dependency

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -22,6 +22,7 @@ used under the terms of the following licences:
 | libjpeg-turbo | [zlib License, IJG License](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/LICENSE.md)        |
 | libpng        | [libpng License](https://github.com/glennrp/libpng/blob/master/LICENSE)                                   |
 | librsvg       | LGPLv3                                                                                                    |
+| libspng       | [BSD 2-Clause, libpng License](https://github.com/randy408/libspng/blob/master/LICENSE)                   |
 | libtiff       | [libtiff License](https://libtiff.gitlab.io/libtiff/misc.html) (BSD-like)                                 |
 | libvips       | LGPLv3                                                                                                    |
 | libwebp       | New BSD License                                                                                           |

--- a/build/lin.sh
+++ b/build/lin.sh
@@ -66,6 +66,7 @@ VERSION_EXIF=0.6.22
 VERSION_LCMS2=2.11
 VERSION_JPEG=2.0.5
 VERSION_PNG16=1.6.37
+VERSION_SPNG=0.6.0
 VERSION_WEBP=1.1.0
 VERSION_TIFF=4.1.0
 VERSION_ORC=0.4.31
@@ -105,6 +106,7 @@ version_latest "exif" "$VERSION_EXIF" "1607"
 version_latest "lcms2" "$VERSION_LCMS2" "9815"
 version_latest "jpeg" "$VERSION_JPEG" "1648"
 version_latest "png" "$VERSION_PNG16" "1705"
+version_latest "spng" "$VERSION_SPNG" "24289"
 version_latest "webp" "$VERSION_WEBP" "1761"
 version_latest "tiff" "$VERSION_TIFF" "13521"
 version_latest "orc" "$VERSION_ORC" "2573"
@@ -201,6 +203,15 @@ curl -Ls https://sourceforge.mirrorservice.org/l/li/libpng/libpng16/${VERSION_PN
 cd ${DEPS}/png16
 ./configure --host=${CHOST} --prefix=${TARGET} --enable-static --disable-shared --disable-dependency-tracking
 make install-strip
+
+mkdir ${DEPS}/spng
+curl -Ls https://github.com/randy408/libspng/archive/v${VERSION_SPNG}.tar.gz | tar xzC ${DEPS}/spng --strip-components=1
+cd ${DEPS}/spng
+patch -p1 < ${PACKAGE}/build/patches/libspng-0.6-fixes.patch
+meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
+  -Dstatic_zlib=true
+ninja -C _build
+ninja -C _build install
 
 mkdir ${DEPS}/webp
 curl -Ls https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${VERSION_WEBP}.tar.gz | tar xzC ${DEPS}/webp --strip-components=1
@@ -410,6 +421,7 @@ printf "{\n\
   \"pixman\": \"${VERSION_PIXMAN}\",\n\
   \"png\": \"${VERSION_PNG16}\",\n\
   \"svg\": \"${VERSION_SVG}\",\n\
+  \"spng\": \"${VERSION_SPNG}\",\n\
   \"tiff\": \"${VERSION_TIFF}\",\n\
   \"vips\": \"${VERSION_VIPS}\",\n\
   \"webp\": \"${VERSION_WEBP}\",\n\

--- a/build/patches/libspng-0.6-fixes.patch
+++ b/build/patches/libspng-0.6-fixes.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Randy <randy408@protonmail.com>
+Date: Wed, 29 Jul 2020 15:31:50 +0200
+Subject: [PATCH 1/1] Ignore spec violation for tRNS chunks (fixes #118)
+
+
+diff --git a/spng/spng.c b/spng/spng.c
+index 1111111..2222222 100644
+--- a/spng/spng.c
++++ b/spng/spng.c
+@@ -208,6 +208,7 @@ struct spng_ctx
+     unsigned streaming: 1;
+ 
+     unsigned encode_only: 1;
++    unsigned strict : 1;
+ 
+     /* input file contains this chunk */
+     struct spng_chunk_bitfield file;
+@@ -1884,7 +1885,14 @@ static int read_non_idat_chunks(spng_ctx *ctx)
+                 }
+                 ctx->trns.n_type3_entries = chunk.length;
+             }
+-            else return SPNG_ETRNS_COLOR_TYPE;
++
++            /* The standard explicitly forbids tRNS chunks for grayscale alpha,
++                truecolor alpha images but libpng only emits a warning by default. */
++            if(ctx->ihdr.color_type == 4 || ctx->ihdr.color_type == 6)
++            {
++                if(ctx->strict) return SPNG_ETRNS_COLOR_TYPE;
++                else continue;
++            }
+ 
+             ctx->file.trns = 1;
+             ctx->stored.trns = 1;


### PR DESCRIPTION
In line with the Windows binaries. I've backported https://github.com/randy408/libspng/commit/b21b214b01ec6d52b8d733e473f1c6910db64d6f to help https://github.com/libvips/libvips/issues/1748.