### PR TITLE
Build binaries with --disable-deprecated

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -336,9 +336,9 @@ mkdir ${DEPS}/vips
 curl -Ls https://github.com/libvips/libvips/releases/download/v${VERSION_VIPS}/vips-${VERSION_VIPS}.tar.gz | tar xzC ${DEPS}/vips --strip-components=1
 cd ${DEPS}/vips
 ./configure --host=${CHOST} --prefix=${TARGET} --enable-shared --disable-static --disable-dependency-tracking \
-  --disable-debug --disable-introspection --without-analyze --without-cfitsio --without-fftw --without-heif \
-  --without-imagequant --without-magick --without-matio --without-nifti --without-OpenEXR --without-openslide \
-  --without-pdfium --without-poppler --without-ppm --without-radiance
+  --disable-debug --disable-deprecated --disable-introspection --without-analyze --without-cfitsio --without-fftw \
+  --without-heif --without-imagequant --without-magick --without-matio --without-nifti --without-OpenEXR \
+  --without-openslide --without-pdfium --without-poppler --without-ppm --without-radiance
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/#_removing_rpath
 sed -i'.bak' 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
 make install-strip


### PR DESCRIPTION
The `--disable-deprecated` option was fixed in libvips 8.10.