### PR TITLE
Build Linux x64 binaries with GCC 9.3.1

### DIFF
--- a/linux-x64/Dockerfile
+++ b/linux-x64/Dockerfile
@@ -12,8 +12,8 @@ RUN \
     advancecomp \
     brotli \
     cmake3 \
-    devtoolset-8-gcc \
-    devtoolset-8-gcc-c++ \
+    devtoolset-9-gcc \
+    devtoolset-9-gcc-c++ \
     glib2-devel \
     gobject-introspection-devel \
     gperf \
@@ -30,9 +30,7 @@ RUN \
 
 # Compiler settings
 ENV \
-  CC="/opt/rh/devtoolset-8/root/usr/bin/gcc" \
-  CXX="/opt/rh/devtoolset-8/root/usr/bin/g++" \
-  PATH="/root/.cargo/bin:$PATH" \
+  PATH="/root/.cargo/bin:/opt/rh/devtoolset-9/root/usr/bin:$PATH" \
   PLATFORM="linux-x64" \
   FLAGS="-O3 -fPIC" \
   MESON="--cross-file=/root/meson.ini"

--- a/linux-x64/Toolchain.cmake
+++ b/linux-x64/Toolchain.cmake
@@ -1,8 +1,3 @@
-SET(CMAKE_C_COMPILER /opt/rh/devtoolset-8/root/usr/bin/gcc)
-SET(CMAKE_AR /opt/rh/devtoolset-8/root/usr/bin/ar)
-SET(CMAKE_STRIP /opt/rh/devtoolset-8/root/usr/bin/strip)
-SET(CMAKE_RANLIB /opt/rh/devtoolset-8/root/usr/bin/ranlib)
-
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/linux-x64/meson.ini
+++ b/linux-x64/meson.ini
@@ -1,12 +1,5 @@
 [binaries]
-c = '/opt/rh/devtoolset-8/root/usr/bin/gcc'
-cpp = '/opt/rh/devtoolset-8/root/usr/bin/g++'
-ar = '/opt/rh/devtoolset-8/root/usr/bin/ar'
-nm = '/opt/rh/devtoolset-8/root/usr/bin/nm'
-ld = '/opt/rh/devtoolset-8/root/usr/bin/ld'
-strip = '/opt/rh/devtoolset-8/root/usr/bin/strip'
 pkgconfig = '/usr/bin/pkg-config'
-ranlib = '/opt/rh/devtoolset-8/root/usr/bin/ranlib'
 
 [paths]
 libdir = 'lib'


### PR DESCRIPTION
By using `devtoolset-9` provided by RHEL/CentOS.