### PR TITLE
Ensure fontconfig has default config location of /etc

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -281,7 +281,8 @@ mkdir ${DEPS}/fontconfig
 curl -Ls https://www.freedesktop.org/software/fontconfig/release/fontconfig-${VERSION_FONTCONFIG}.tar.xz | tar xJC ${DEPS}/fontconfig --strip-components=1
 cd ${DEPS}/fontconfig
 ./configure --host=${CHOST} --prefix=${TARGET} --enable-static --disable-shared --disable-dependency-tracking \
-  --with-expat-includes=${TARGET}/include --with-expat-lib=${TARGET}/lib --sysconfdir=/etc --disable-docs
+  --with-expat-includes=${TARGET}/include --with-expat-lib=${TARGET}/lib ${LINUX:+--sysconfdir=/etc} \
+  ${DARWIN:+--sysconfdir=/usr/local/etc} --disable-docs
 make install-strip
 
 mkdir ${DEPS}/harfbuzz


### PR DESCRIPTION
I just spotted `sysconfdir` was changed in commit ee05217 but I think this value needs to be hard-coded to `/etc` for Linux. (I'm experiencing "Cannot load default config file" warnings.)

However given this script is also used for macOS, I'm unsure this will be correct e.g. homebrew uses `/usr/local/etc/`. Any thoughts @kleisauke ?