### PR TITLE
Add Windows arm64 support

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -35,7 +35,7 @@ jobs:
           - 'linux-arm64v8'
           - 'win32-ia32'
           - 'win32-x64'
-          - 'win32-arm64'
+          - 'win32-arm64v8'
         experimental: [false]
         include:
           - os: macos-10.15

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -35,6 +35,7 @@ jobs:
           - 'linux-arm64v8'
           - 'win32-ia32'
           - 'win32-x64'
+          - 'win32-arm64'
         experimental: [false]
         include:
           - os: macos-10.15

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The output of libvips' [build-win64-mxe](https://github.com/libvips/build-win64-
 
 * [win32-ia32](win32-ia32/Dockerfile)
 * [win32-x64](win32-x64/Dockerfile)
-* [win32-arm64](win32-arm64/Dockerfile)
+* [win32-arm64v8](win32-arm64v8/Dockerfile)
 
 ### macOS
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The output of libvips' [build-win64-mxe](https://github.com/libvips/build-win64-
 
 * [win32-ia32](win32-ia32/Dockerfile)
 * [win32-x64](win32-x64/Dockerfile)
+* [win32-arm64](win32-arm64/Dockerfile)
 
 ### macOS
 

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,7 @@ if [ $# -lt 1 ]; then
   echo "Possible values for PLATFORM are:"
   echo "- win32-ia32"
   echo "- win32-x64"
+  echo "- win32-arm64"
   echo "- linux-x64"
   echo "- linuxmusl-x64"
   echo "- linux-armv6"
@@ -61,7 +62,7 @@ for baseimage in centos:7 debian:buster debian:bullseye alpine:3.11; do
 done
 
 # Windows
-for flavour in win32-ia32 win32-x64; do
+for flavour in win32-ia32 win32-x64 win32-arm64; do
   if [ $PLATFORM = "all" ] || [ $PLATFORM = $flavour ]; then
     echo "Building $flavour..."
     docker build -t vips-dev-$flavour $flavour

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ if [ $# -lt 1 ]; then
   echo "Possible values for PLATFORM are:"
   echo "- win32-ia32"
   echo "- win32-x64"
-  echo "- win32-arm64"
+  echo "- win32-arm64v8"
   echo "- linux-x64"
   echo "- linuxmusl-x64"
   echo "- linux-armv6"
@@ -62,7 +62,7 @@ for baseimage in centos:7 debian:buster debian:bullseye alpine:3.11; do
 done
 
 # Windows
-for flavour in win32-ia32 win32-x64 win32-arm64; do
+for flavour in win32-ia32 win32-x64 win32-arm64v8; do
   if [ $PLATFORM = "all" ] || [ $PLATFORM = $flavour ]; then
     echo "Building $flavour..."
     docker build -t vips-dev-$flavour $flavour

--- a/build/win.sh
+++ b/build/win.sh
@@ -9,9 +9,15 @@ CURL="curl --silent --location --retry 3 --retry-max-time 30"
 # Fetch and unzip
 mkdir /vips
 cd /vips
-BITS=${PLATFORM: -2}
-$CURL -O https://github.com/libvips/build-win64-mxe/releases/download/v${VERSION_VIPS}-build2/vips-dev-w${BITS}-web-${VERSION_VIPS}-static.zip
-unzip vips-dev-w${BITS}-web-${VERSION_VIPS}-static.zip
+
+if [[ $PLATFORM == "win32-arm64" ]]; then
+  $CURL -O https://github.com/libvips/build-win64-mxe/releases/download/v${VERSION_VIPS}-build2/vips-dev-arm64-web-${VERSION_VIPS}-static.zip
+  unzip vips-dev-arm64-web-${VERSION_VIPS}-static.zip
+else
+  BITS=${PLATFORM: -2}
+  $CURL -O https://github.com/libvips/build-win64-mxe/releases/download/v${VERSION_VIPS}-build2/vips-dev-w${BITS}-web-${VERSION_VIPS}-static.zip
+  unzip vips-dev-w${BITS}-web-${VERSION_VIPS}-static.zip
+fi
 
 # Clean and zip
 cd /vips/vips-dev-${VERSION_VIPS_SHORT}

--- a/build/win.sh
+++ b/build/win.sh
@@ -10,7 +10,7 @@ CURL="curl --silent --location --retry 3 --retry-max-time 30"
 mkdir /vips
 cd /vips
 
-if [[ $PLATFORM == "win32-arm64" ]]; then
+if [[ $PLATFORM == "win32-arm64v8" ]]; then
   $CURL -O https://github.com/libvips/build-win64-mxe/releases/download/v${VERSION_VIPS}-build2/vips-dev-arm64-web-${VERSION_VIPS}-static.zip
   unzip vips-dev-arm64-web-${VERSION_VIPS}-static.zip
 else

--- a/win32-arm64/Dockerfile
+++ b/win32-arm64/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:buster
+LABEL maintainer="Lovell Fuller <npm@lovell.info>"
+
+# Create Debian-based container suitable for post-processing ARM64 Windows binaries
+
+RUN apt-get update && apt-get install -y advancecomp brotli curl zip
+
+ENV PLATFORM="win32-arm64"

--- a/win32-arm64v8/Dockerfile
+++ b/win32-arm64v8/Dockerfile
@@ -5,4 +5,4 @@ LABEL maintainer="Lovell Fuller <npm@lovell.info>"
 
 RUN apt-get update && apt-get install -y advancecomp brotli curl zip
 
-ENV PLATFORM="win32-arm64"
+ENV PLATFORM="win32-arm64v8"


### PR DESCRIPTION
Version 8.10.2 of `build-win64-mxe` added support for Windows ARM32+ARM64: 

https://github.com/libvips/build-win64-mxe/releases/tag/v8.10.2

This PR adds support for Windows ARM64 to `sharp-libvips`. Since Microsoft is focused on ARM64 only moving forward (AFAIK), I only added that version. I'm happy to add ARM32 as well if you think that will benefit the community. 😊 