### PR TITLE
Use stable version of glib

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -69,7 +69,7 @@ CURL="curl --silent --location --retry 3 --retry-max-time 30"
 # Dependency version numbers
 VERSION_ZLIB=1.2.11
 VERSION_FFI=3.3
-VERSION_GLIB=2.67.2
+VERSION_GLIB=2.66.4
 VERSION_XML2=2.9.10
 VERSION_GSF=1.14.47
 VERSION_EXIF=0.6.22
@@ -111,7 +111,7 @@ version_latest() {
 }
 version_latest "zlib" "$VERSION_ZLIB" "5303"
 version_latest "ffi" "$VERSION_FFI" "1611"
-version_latest "glib" "$VERSION_GLIB" "10024"
+#version_latest "glib" "$VERSION_GLIB" "10024" # latest version in release monitoring is development version
 version_latest "xml2" "$VERSION_XML2" "1783"
 version_latest "gsf" "$VERSION_GSF" "1980"
 version_latest "exif" "$VERSION_EXIF" "1607"


### PR DESCRIPTION
I noticed that the build is using the glib development version. In case this is not the intention, here is a PR that switches to 2.66.4, [the current stable release](https://developer.gnome.org/glib/). Unfortunately release-monitoring reports the latest dev, so I disabled the version check.