### PR TITLE
Fix gdk-pixbuf build on macOS

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -280,7 +280,8 @@ sed -i'.bak' "/\[ 'bmp'/{N;N;N;d;}" gdk-pixbuf/meson.build
 sed -i'.bak' "/\[ 'pnm'/d" gdk-pixbuf/meson.build
 sed -i'.bak' "/\[ 'xpm'/{N;N;N;N;d;}" gdk-pixbuf/meson.build
 # Skip executables
-sed -i'.bak' "/gdk-pixbuf-csource/{N;N;d}" gdk-pixbuf/meson.build
+sed -i'.bak' "/gdk-pixbuf-csource/,+2d" gdk-pixbuf/meson.build
+sed -i'.bak' "/gdk-pixbuf-query-loaders/d" build-aux/post-install.sh
 # Ensure meson can find libjpeg when cross-compiling
 sed -i'.bak' "s/has_header('jpeglib.h')/has_header('jpeglib.h', args: '-I\/target\/include')/g" meson.build
 sed -i'.bak' "s/cc.find_library('jpeg'/dependency('libjpeg'/g" meson.build

--- a/build/lin.sh
+++ b/build/lin.sh
@@ -281,6 +281,10 @@ sed -i'.bak' "/\[ 'pnm'/d" gdk-pixbuf/meson.build
 sed -i'.bak' "/\[ 'xpm'/{N;N;N;N;d;}" gdk-pixbuf/meson.build
 # Skip executables
 sed -i'.bak' "/gdk-pixbuf-csource/{N;N;d;}" gdk-pixbuf/meson.build
+sed -i'.bak' "/loaders_cache = custom/{N;N;N;N;N;N;N;N;N;c\\
+  loaders_cache = []\\
+  loaders_dep = declare_dependency()
+}" gdk-pixbuf/meson.build
 sed -i'.bak' "/gdk-pixbuf-query-loaders/d" build-aux/post-install.sh
 # Ensure meson can find libjpeg when cross-compiling
 sed -i'.bak' "s/has_header('jpeglib.h')/has_header('jpeglib.h', args: '-I\/target\/include')/g" meson.build

--- a/build/lin.sh
+++ b/build/lin.sh
@@ -280,7 +280,7 @@ sed -i'.bak' "/\[ 'bmp'/{N;N;N;d;}" gdk-pixbuf/meson.build
 sed -i'.bak' "/\[ 'pnm'/d" gdk-pixbuf/meson.build
 sed -i'.bak' "/\[ 'xpm'/{N;N;N;N;d;}" gdk-pixbuf/meson.build
 # Skip executables
-sed -i'.bak' "/gdk-pixbuf-csource/,+2d" gdk-pixbuf/meson.build
+sed -i'.bak' "/gdk-pixbuf-csource/{N;N;d;}" gdk-pixbuf/meson.build
 sed -i'.bak' "/gdk-pixbuf-query-loaders/d" build-aux/post-install.sh
 # Ensure meson can find libjpeg when cross-compiling
 sed -i'.bak' "s/has_header('jpeglib.h')/has_header('jpeglib.h', args: '-I\/target\/include')/g" meson.build


### PR DESCRIPTION
The changes in 151cb8c3d892b9 broke the gdk-pixbuf build for me on darwin-x64. The command to delete the executables had no final semicolon, which causes an error using the `sed` binary installed on my Mac (it works fine with `gnu-sed`). Furthermore, the meson setup failed because of a missing variable [here](https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/blob/master/gdk-pixbuf/meson.build#L322) and the post-install script failed because it calls `gdk-pixbuf-query-loaders`, which we have not built.

Both these latter errors are in `if not meson.is_cross_build()` branches, which I don't seem to hit when running the linux-x64 build via docker, though I'm not entirely sure why that this is. If there is another reason for why the linux-x64 build does not fail, this PR might not be necessary at all (except for the missing semicolon).

Also, swapping out ten lines for two is very brittle using the sed syntax (using `/.../,+9c` instead of the nine `N;` would make it slightly better but is not supported by the default `sed` on macOS). Let me know if you would prefer a different approach!