### PR TITLE
Revert "glib: use patch from Alpine Linux (#80)"

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -172,7 +172,8 @@ mkdir ${DEPS}/glib
 $CURL https://download.gnome.org/sources/glib/$(without_patch $VERSION_GLIB)/glib-${VERSION_GLIB}.tar.xz | tar xJC ${DEPS}/glib --strip-components=1
 cd ${DEPS}/glib
 if [ "${PLATFORM%-*}" == "linuxmusl" ]; then
-  $CURL https://git.alpinelinux.org/aports/plain/main/glib/musl-libintl.patch | patch -p1
+  #$CURL https://git.alpinelinux.org/aports/plain/main/glib/musl-libintl.patch | patch -p1 # not compatible with latest glib
+  $CURL https://gist.github.com/kleisauke/f4bda6fc3030cf7b8a4fdb88e2ce8e13/raw/246ac97dfba72ad7607c69eed1810b2354cd2e86/musl-libintl.patch | patch -p1
 fi
 LDFLAGS=${LDFLAGS/\$/} meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Dinternal_pcre=true -Dtests=false -Dinstalled_tests=false -Dlibmount=disabled -Dlibelf=disabled ${DARWIN:+-Dbsymbolic_functions=false}


### PR DESCRIPTION
The Alpine patch seems to apply without problems, but further on it causes issues when configuring GLib, see for example:
https://github.com/kleisauke/libvips-packaging/runs/1777505762

Sorry for not testing this properly in the first place.