### PR TITLE
Reduce size of binaries by up to 10%

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ for flavour in darwin-x64 darwin-arm64v8; do
     # See:
     # https://forums.developer.apple.com/thread/121887
     # https://trac.ffmpeg.org/ticket/8073#comment:12
-    export FLAGS="-O3 -fPIC -fno-stack-check"
+    export FLAGS="-fno-stack-check"
 
     if [ $PLATFORM = "darwin-arm64v8" ]; then
       # ARM64 builds work via cross compilation from an x86_64 machine

--- a/linux-arm64v8/Dockerfile
+++ b/linux-arm64v8/Dockerfile
@@ -49,7 +49,7 @@ ENV \
   PLATFORM="linux-arm64v8" \
   CHOST="aarch64-linux-gnu" \
   RUST_TARGET="aarch64-unknown-linux-gnu" \
-  FLAGS="-march=armv8-a -O3 -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" \
+  FLAGS="-march=armv8-a -D_GLIBCXX_USE_CXX11_ABI=0" \
   MESON="--cross-file=/root/meson.ini"
 
 COPY Toolchain.cmake /root/

--- a/linux-armv6/Dockerfile
+++ b/linux-armv6/Dockerfile
@@ -50,7 +50,7 @@ ENV \
   PLATFORM="linux-armv6" \
   CHOST="arm-rpi-linux-gnueabihf" \
   RUST_TARGET="arm-unknown-linux-gnueabihf" \
-  FLAGS="-marm -mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard -O3 -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" \
+  FLAGS="-marm -mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard -D_GLIBCXX_USE_CXX11_ABI=0" \
   WITHOUT_NEON="true" \
   MESON="--cross-file=/root/meson.ini"
 

--- a/linux-armv7/Dockerfile
+++ b/linux-armv7/Dockerfile
@@ -49,7 +49,7 @@ ENV \
   PLATFORM="linux-armv7" \
   CHOST="arm-linux-gnueabihf" \
   RUST_TARGET="arm-unknown-linux-gnueabihf" \
-  FLAGS="-marm -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" \
+  FLAGS="-marm -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -D_GLIBCXX_USE_CXX11_ABI=0" \
   MESON="--cross-file=/root/meson.ini"
 
 COPY Toolchain.cmake /root/

--- a/linux-x64/Dockerfile
+++ b/linux-x64/Dockerfile
@@ -40,7 +40,7 @@ RUN \
 # Compiler settings
 ENV \
   PLATFORM="linux-x64" \
-  FLAGS="-O3 -fPIC" \
+  FLAGS="-march=westmere" \
   MESON="--cross-file=/root/meson.ini"
 
 COPY Toolchain.cmake /root/

--- a/linuxmusl-x64/Dockerfile
+++ b/linuxmusl-x64/Dockerfile
@@ -46,7 +46,7 @@ RUN \
 # Compiler settings
 ENV \
   PLATFORM="linuxmusl-x64" \
-  FLAGS="-O3 -fPIC"
+  FLAGS="-march=westmere"
 
 # Musl defaults to static libs but we need them to be dynamic for host toolchain.
 # The toolchain will produce static libs by default.


### PR DESCRIPTION
This PR allows the size vs perf optimisation level to be set per dependency.

There's no change (`-O3`) for vips, gif, orc, webp, spng, png16, jpeg, heif, lcms2, zlib, aom; everything else is optimised for size (`-Os`). This accounts for 7-9% reduction in binary size.

For Linux, it adds flags that allows the linker to remove unused sections (unsupported by cairo). This accounts for 1% reduction in binary size.

For Linux x64, it sets a minimum CPU requirement of Westmere (circa 2010) or later. This allows gcc to use CLMUL intrinsics, which helps improve zlib (de)compression performance (whilst we wait for zlib-ng).

@kleisauke Is there anything you think could be added/improved? Perhaps this approach might be something to consider for the Windows builds too?