### PR TITLE
Build a more minimal libxml2

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -216,9 +216,10 @@ ninja -C _build install
 mkdir ${DEPS}/xml2
 $CURL http://xmlsoft.org/sources/libxml2-${VERSION_XML2}.tar.gz | tar xzC ${DEPS}/xml2 --strip-components=1
 cd ${DEPS}/xml2
+# Remove --with-regexps flag from v2.10.0+
 ./configure --host=${CHOST} --prefix=${TARGET} --enable-static --disable-shared --disable-dependency-tracking \
-  --without-python --without-debug --without-docbook --without-ftp --without-html --without-legacy \
-  --without-push --without-schematron --without-lzma --with-zlib=${TARGET}
+  --with-minimum --with-reader --with-writer --with-valid --with-http --with-tree --with-regexps \
+  --without-python --without-lzma --with-zlib=${TARGET}
 make install-strip
 
 mkdir ${DEPS}/gsf


### PR DESCRIPTION
Rather than exclude some modules that are not required, this approach excludes all optional modules then includes only what is needed.

This reduces the binary size by ~0.3MB.

When https://gitlab.gnome.org/GNOME/libxml2/-/commit/106757e8c1e26ad9b8c924c7f304074b79e082c5 is released we can also remove the `--with-regexps` flag.

@kleisauke We might want to use this approach for the Windows builds too.