### PR TITLE
Switch from zlib to zlib-ng (stable release candidate)

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -33,7 +33,7 @@ used under the terms of the following licences:
 | orc           | [orc License](https://gitlab.freedesktop.org/gstreamer/orc/blob/master/COPYING) (BSD-like)                |
 | pango         | LGPLv3                                                                                                    |
 | pixman        | MIT Licence                                                                                               |
-| zlib          | [zlib Licence](https://github.com/madler/zlib/blob/master/zlib.h)                                         |
+| zlib-ng       | [zlib Licence](https://github.com/zlib-ng/zlib-ng/blob/develop/LICENSE.md)                                |
 
 Use of libraries under the terms of the LGPLv3 is via the
 "any later version" clause of the LGPLv2 or LGPLv2.1.


### PR DESCRIPTION
The only changes to zlib-ng since RC2 appear to relate to tests, docs and CI so I'm happy it will be very close to the (supported) release, which means it's worth making the switch now so we can get some testing in too.

Closes #25