### PR TITLE
Linux x64: remove async unwind tables, ~7% smaller binary size

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -29,9 +29,10 @@ mkdir ${TARGET}
 export FLAGS+=" -Os -fPIC"
 
 # Force "new" C++11 ABI compliance
+# Remove async exception unwind/backtrace tables
 # Allow linker to remove unused sections
 if [ "$LINUX" = true ]; then
-  export FLAGS+=" -D_GLIBCXX_USE_CXX11_ABI=1 -ffunction-sections -fdata-sections"
+  export FLAGS+=" -D_GLIBCXX_USE_CXX11_ABI=1 -fno-asynchronous-unwind-tables -ffunction-sections -fdata-sections"
 fi
 
 # Common build paths and flags


### PR DESCRIPTION
This change makes getting a backtrace slightly more difficult in some circumstances, or at least the output is less useful, but with a worthwhile reduction in binary size.

It makes very little difference with macOS/clang, presumably as it is able to optimise this away already, so this change is for Linux/gcc only. There is also minimal impact on cross-compiled ARM binaries, so perhaps we should exclude them too?

Before:
```
22742608 libvips-cpp.so.42.12.7
 8166054 libvips-8.10.6-linux-x64.tar.br
 9891496 libvips-8.10.6-linux-x64.tar.gz
```
After:
```
21145168 libvips-cpp.so.42.12.7
 7767290 libvips-8.10.6-linux-x64.tar.br
 9354659 libvips-8.10.6-linux-x64.tar.gz
```
