### PR TITLE
xml2: build without support for regular expressions

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -223,10 +223,9 @@ ninja -C _build install
 mkdir ${DEPS}/xml2
 $CURL http://xmlsoft.org/sources/libxml2-${VERSION_XML2}.tar.gz | tar xzC ${DEPS}/xml2 --strip-components=1
 cd ${DEPS}/xml2
-# Remove --with-regexps flag from v2.10.0+
 ./configure --host=${CHOST} --prefix=${TARGET} --enable-static --disable-shared --disable-dependency-tracking \
-  --with-minimum --with-reader --with-writer --with-valid --with-http --with-tree --with-regexps \
-  --without-python --without-lzma --with-zlib=${TARGET}
+  --with-minimum --with-reader --with-writer --with-valid --with-http --with-tree --without-python --without-lzma \
+  --with-zlib=${TARGET}
 make install-strip
 
 mkdir ${DEPS}/gsf


### PR DESCRIPTION
We can safely remove the `--with-regexps` flag, now that libxml2 v2.9.12 has been released.