### PR TITLE
Linux x64: upgrade to gcc 10

### DIFF
--- a/linux-x64/Dockerfile
+++ b/linux-x64/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Lovell Fuller <npm@lovell.info>"
 ENV \
   RUSTUP_HOME="/usr/local/rustup" \
   CARGO_HOME="/usr/local/cargo" \
-  PATH="/usr/local/cargo/bin:/opt/rh/devtoolset-9/root/usr/bin:$PATH"
+  PATH="/usr/local/cargo/bin:/opt/rh/devtoolset-10/root/usr/bin:$PATH"
 
 # Build dependencies
 RUN \
@@ -18,8 +18,8 @@ RUN \
     advancecomp \
     brotli \
     cmake3 \
-    devtoolset-9-gcc \
-    devtoolset-9-gcc-c++ \
+    devtoolset-10-gcc \
+    devtoolset-10-gcc-c++ \
     glib2-devel \
     gobject-introspection-devel \
     gperf \


### PR DESCRIPTION
Reduces final binary size by ~2% (from 20974256 to 20539888 bytes), which I guess may be due to the following change:

> `-finline-functions` is now enabled at `-O2` and was retuned for better code size versus runtime performance trade-offs

https://gcc.gnu.org/gcc-10/changes.html

I think this is a relatively safe upgrade, but doing so via a PR for comments, if any.