### PR TITLE
glib: remove deprecated/unused GRegex via patch

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -208,6 +208,7 @@ cd ${DEPS}/glib
 if [ "${PLATFORM%-*}" == "linuxmusl" ] || [ "$DARWIN" = true ]; then
   $CURL https://gist.github.com/kleisauke/f6dcbf02a9aa43fd582272c3d815e7a8/raw/13049037ce45592d0eb76a12a761212bc48bc879/glib-proxy-libintl.patch | patch -p1
 fi
+$CURL https://gist.githubusercontent.com/lovell/7e0ce65249b951d5be400fb275de3924/raw/1a833ef4263271d299587524198b024eb5cc4f34/glib-without-gregex.patch | patch -p1
 LDFLAGS=${LDFLAGS/\$/} meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Dinternal_pcre=true -Dtests=false -Dinstalled_tests=false -Dlibmount=disabled -Dlibelf=disabled ${DARWIN:+-Dbsymbolic_functions=false}
 ninja -C _build


### PR DESCRIPTION
The glib maintainers started deprecating the outdated, PCRE1-based GRegex about 6 years ago:

https://bugzilla.gnome.org/show_bug.cgi?id=755693
https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1451

This means we can pre-emptively remove it as there is no dependence on it from any of the libraries we rely on.

The sharp unit tests pass using the output.

The resultant binaries are only about 150KB smaller, but it all helps.