### PR TITLE
Bump dep: glib

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -99,7 +99,7 @@ CURL="curl --silent --location --retry 3 --retry-max-time 30"
 # Dependency version numbers
 VERSION_ZLIB_NG=2.0.5
 VERSION_FFI=3.4.2
-VERSION_GLIB=2.69.0
+VERSION_GLIB=2.69.1
 VERSION_XML2=2.9.12
 VERSION_GSF=1.14.47
 VERSION_EXIF=0.6.22


### PR DESCRIPTION
(I've no idea why Anitya sees this as pre-release: https://release-monitoring.org/project/10024/)