### PR TITLE
linux-arm64v8: replace cross-compilation with native build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2.1
+orbs:
+  github-cli: circleci/github-cli@1.0
+
+workflows:
+  build:
+    jobs:
+      - linux-arm64v8:
+          filters:
+            tags:
+              only: /^v.*/
+
+jobs:
+  linux-arm64v8:
+    resource_class: arm.medium
+    machine:
+      image: ubuntu-2004:202101-01
+    steps:
+      - checkout
+      - github-cli/setup
+      - run: ./build.sh $(cat LIBVIPS_VERSION) linux-arm64v8
+      - run: ./integrity.sh
+      - when:
+          condition: <<pipeline.git.tag>>
+          steps:
+            - run: gh release upload --repo lovell/sharp-libvips $CIRCLE_TAG *.tar.gz *.tar.br *.integrity

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,7 +27,6 @@ jobs:
           - 'linux-x64'
           - 'linux-armv6'
           - 'linux-armv7'
-          - 'linux-arm64v8'
           - 'linuxmusl-x64'
           - 'linuxmusl-arm64v8'
           - 'win32-ia32'

--- a/build/lin.sh
+++ b/build/lin.sh
@@ -455,6 +455,10 @@ sed -i'.bak' "s/^\(Requires:.*\)/\1 cairo-gobject pangocairo/" librsvg.pc.in
 sed -i'.bak' "s/, \"rlib\"//" Cargo.toml
 # Skip executables
 sed -i'.bak' "/SCRIPTS = /d" Makefile.in
+# Use target/CARGO_BUILD_TARGET/release instead of target/release when set
+if [[ $CARGO_BUILD_TARGET ]]; then
+  sed -i'.bak' "s/@RUST_TARGET_SUBDIR@/$CARGO_BUILD_TARGET\/@RUST_TARGET_SUBDIR@/" Makefile.in
+fi
 ./configure --host=${CHOST} --prefix=${TARGET} --enable-static --disable-shared --disable-dependency-tracking \
   --disable-introspection --disable-tools --disable-pixbuf-loader --disable-nls --without-libiconv-prefix --without-libintl-prefix \
   ${DARWIN:+--disable-Bsymbolic}

--- a/linux-arm64v8/Dockerfile
+++ b/linux-arm64v8/Dockerfile
@@ -1,40 +1,33 @@
-FROM debian:bullseye
+FROM arm64v8/centos:7
 LABEL maintainer="Lovell Fuller <npm@lovell.info>"
 
-# Create Debian-based container suitable for cross-compiling Linux ARM64v8-A binaries
+# Create CentOS 7 (glibc 2.17) container suitable for building Linux ARM64v8-A binaries
 
 # Path settings
 ENV \
   RUSTUP_HOME="/usr/local/rustup" \
   CARGO_HOME="/usr/local/cargo" \
-  PATH="/usr/local/cargo/bin:$PATH"
+  PATH="/usr/local/cargo/bin:/opt/rh/devtoolset-10/root/usr/bin:$PATH"
 
 # Build dependencies
 RUN \
-  apt-get update && \
-  apt-get install -y curl && \
-  dpkg --add-architecture arm64 && \
-  apt-get update && \
-  apt-get install -y \
+  yum update -y && \
+  yum install -y epel-release centos-release-scl && \
+  yum group install -y "Development Tools" && \
+  yum install -y --setopt=tsflags=nodocs \
     advancecomp \
-    autoconf \
-    autopoint \
     brotli \
-    cmake \
-    crossbuild-essential-arm64 \
-    gettext \
-    git \
-    gobject-introspection \
+    cmake3 \
+    devtoolset-10-gcc \
+    devtoolset-10-gcc-c++ \
+    glib2-devel \
+    gobject-introspection-devel \
     gperf \
-    gtk-doc-tools \
-    intltool \
+    gtk-doc \
     jq \
-    libglib2.0-dev \
-    libtool \
     nasm \
-    ninja-build \
-    python3-pip \
-    texinfo \
+    prelink \
+    python3 \
     && \
   curl https://sh.rustup.rs -sSf | sh -s -- -y \
     --no-modify-path \
@@ -43,7 +36,9 @@ RUN \
     && \
   rustup component add rust-src && \
   rustup target add aarch64-unknown-linux-gnu && \
-  pip3 install meson
+  ln -s /usr/bin/cmake3 /usr/bin/cmake && \
+  pip3 install --upgrade pip && \
+  pip3 install meson ninja
 
 # Rebuild the standard library of Rust to avoid collisions with system libraries.
 # See: https://github.com/lovell/sharp-libvips/issues/109
@@ -54,10 +49,8 @@ build-std-features = [\"panic_immediate_abort\"]" > $CARGO_HOME/config.toml
 
 # Compiler settings
 ENV \
-  PKG_CONFIG="/usr/bin/aarch64-linux-gnu-pkg-config" \
   PLATFORM="linux-arm64v8" \
-  CHOST="aarch64-linux-gnu" \
-  RUST_TARGET="aarch64-unknown-linux-gnu" \
+  CARGO_BUILD_TARGET="aarch64-unknown-linux-gnu" \
   FLAGS="-march=armv8-a" \
   MESON="--cross-file=/root/meson.ini"
 

--- a/linux-arm64v8/Toolchain.cmake
+++ b/linux-arm64v8/Toolchain.cmake
@@ -1,13 +1,3 @@
-set(CMAKE_SYSTEM_NAME Linux)
-set(CMAKE_SYSTEM_VERSION 1)
-set(CMAKE_SYSTEM_PROCESSOR aarch64)
-
-SET(CMAKE_C_COMPILER /usr/bin/aarch64-linux-gnu-gcc)
-set(CMAKE_CXX_COMPILER /usr/bin/aarch64-linux-gnu-g++)
-SET(CMAKE_AR /usr/bin/aarch64-linux-gnu-gcc-ar)
-SET(CMAKE_STRIP /usr/bin/aarch64-linux-gnu-gcc-strip)
-SET(CMAKE_RANLIB /usr/bin/aarch64-linux-gnu-gcc-ranlib)
-
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/linux-arm64v8/meson.ini
+++ b/linux-arm64v8/meson.ini
@@ -1,18 +1,6 @@
-[host_machine]
-system = 'linux'
-cpu_family = 'aarch64'
-cpu = 'armv8-a'
-endian = 'little'
-
 [binaries]
-c = '/usr/bin/aarch64-linux-gnu-gcc'
-cpp = '/usr/bin/aarch64-linux-gnu-g++'
-ar = '/usr/bin/aarch64-linux-gnu-gcc-ar'
-nm = '/usr/bin/aarch64-linux-gnu-gcc-nm'
-ld = '/usr/bin/aarch64-linux-gnu-gcc-ld'
-strip = '/usr/bin/aarch64-linux-gnu-strip'
-pkgconfig = '/usr/bin/aarch64-linux-gnu-pkg-config'
-ranlib = '/usr/bin/aarch64-linux-gnu-gcc-ranlib'
+pkgconfig = '/usr/bin/pkg-config'
+strip = '/usr/bin/strip'
 
 [paths]
 libdir = 'lib'


### PR DESCRIPTION
Closes #114

- Uses Centos 7 with latest gcc 10 (currently v10.2.1) so the glibc minimum version will drop from 2.31 to 2.17
- Runs on CircleCI ARM64 environment - https://circleci.com/docs/2.0/arm-resources/
- Adds workaround for librsvg not yet supporting rust aarch64 nightly multi-target (should probably patch this upstream)

Example build log - https://circleci.com/api/v1.1/project/github/lovell/sharp-libvips/20/output/103/0?file=true

@kleisauke Is this something you might be able to take advantage of for the net-vips packaging too? This change will allow use of e.g. the new ARM-based Lambda environment in AWS.