### PR TITLE
ARM64: build librsvg without the -Zbuild-std feature flag

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -184,14 +184,7 @@ if [ "$DARWIN" = true ]; then
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --no-modify-path --profile minimal ${DARWIN_ARM:+--default-toolchain nightly}
   if [ "$DARWIN_ARM" = true ]; then
-    ${CARGO_HOME}/bin/rustup component add rust-src 
     ${CARGO_HOME}/bin/rustup target add aarch64-apple-darwin
-
-    # Rebuild the standard library of Rust to avoid collisions with system libraries.
-    # See: https://github.com/lovell/sharp-libvips/issues/109
-    printf "[unstable]\n\
-build-std = [\"std\", \"panic_abort\"]\n\
-build-std-features = [\"panic_immediate_abort\"]" > ${CARGO_HOME}/config.toml
   fi
 fi
 
@@ -446,16 +439,6 @@ ninja -C _build install
 mkdir ${DEPS}/svg
 $CURL https://download.gnome.org/sources/librsvg/$(without_patch $VERSION_SVG)/librsvg-${VERSION_SVG}.tar.xz | tar xJC ${DEPS}/svg --strip-components=1
 cd ${DEPS}/svg
-# Allow building vendored sources with `-Zbuild-std`, see:
-# https://github.com/rust-lang/wg-cargo-std-aware/issues/23#issuecomment-720455524
-if [[ $PLATFORM == *"-arm64v8" ]]; then
-  RUST_SRC=$(rustc +nightly --print sysroot)/lib/rustlib/src/rust
-  RUST_TEST=$RUST_SRC/library/test
-  # Copy the Cargo.lock for Rust to places `vendor` will see
-  cp $RUST_SRC/Cargo.lock $RUST_TEST
-  # Actually do the vendor
-  cargo +nightly vendor -s $RUST_TEST/Cargo.toml
-fi
 sed -i'.bak' "s/^\(Requires:.*\)/\1 cairo-gobject pangocairo/" librsvg.pc.in
 # LTO optimization does not work for staticlib+rlib compilation
 sed -i'.bak' "s/, \"rlib\"//" Cargo.toml

--- a/linux-arm64v8/Dockerfile
+++ b/linux-arm64v8/Dockerfile
@@ -34,18 +34,10 @@ RUN \
     --profile minimal \
     --default-toolchain nightly \
     && \
-  rustup component add rust-src && \
   rustup target add aarch64-unknown-linux-gnu && \
   ln -s /usr/bin/cmake3 /usr/bin/cmake && \
   pip3 install --upgrade pip && \
   pip3 install meson ninja
-
-# Rebuild the standard library of Rust to avoid collisions with system libraries.
-# See: https://github.com/lovell/sharp-libvips/issues/109
-RUN \
-  printf "[unstable]\n\
-build-std = [\"std\", \"panic_abort\"]\n\
-build-std-features = [\"panic_immediate_abort\"]" > $CARGO_HOME/config.toml
 
 # Compiler settings
 ENV \

--- a/linuxmusl-arm64v8/Dockerfile
+++ b/linuxmusl-arm64v8/Dockerfile
@@ -45,16 +45,8 @@ RUN \
     --profile minimal \
     --default-toolchain nightly \
     && \
-  rustup component add rust-src && \
   rustup target add aarch64-unknown-linux-musl && \
   pip3 install meson
-
-# Rebuild the standard library of Rust to avoid collisions with system libraries.
-# See: https://github.com/lovell/sharp-libvips/issues/109
-RUN \
-  printf "[unstable]\n\
-build-std = [\"std\", \"panic_abort\"]\n\
-build-std-features = [\"panic_immediate_abort\"]" > $CARGO_HOME/config.toml
 
 # Compiler settings
 ENV \
@@ -69,7 +61,7 @@ ENV \
 # The toolchain will produce static libs by default.
 # We also need to add the directory containing libc.a to the library search path.
 ENV \
-  RUSTFLAGS="-C target-feature=-crt-static -Lnative=/aarch64-linux-musl/lib"
+  RUSTFLAGS="-Ctarget-feature=-crt-static -Lnative=/aarch64-linux-musl/lib"
 
 COPY Toolchain.cmake /root/
 COPY meson.ini /root/


### PR DESCRIPTION
This feature flag is no longer necessary after PR rust-lang/compiler-builtins#444. 

The only downside I can think of is that the standard library is now built without `panic_immediate_abort`.