### PR TITLE
Use `git ls-remote` to fetch the latest tag

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -49,8 +49,6 @@ jobs:
     - name: Build ${{ matrix.platform }}
       id: build-release
       run: ./build.sh $(cat LIBVIPS_VERSION) ${{ matrix.platform }}
-      env:
-        GITHUB_AUTH_HEADER: "--header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'"
     - name: Generate integrity checksums
       id: integrity
       run: ./integrity.sh

--- a/build.sh
+++ b/build.sh
@@ -92,6 +92,6 @@ for flavour in linux-x64 linuxmusl-x64 linux-armv6 linux-armv7 linux-arm64v8 lin
   if [ $PLATFORM = "all" ] || [ $PLATFORM = $flavour ]; then
     echo "Building $flavour..."
     docker build -t vips-dev-$flavour $flavour
-    docker run --rm -e "VERSION_VIPS=${VERSION_VIPS}" -e VERSION_LATEST_REQUIRED -e GITHUB_AUTH_HEADER -v $PWD:/packaging vips-dev-$flavour sh -c "/packaging/build/lin.sh"
+    docker run --rm -e "VERSION_VIPS=${VERSION_VIPS}" -e VERSION_LATEST_REQUIRED -v $PWD:/packaging vips-dev-$flavour sh -c "/packaging/build/lin.sh"
   fi
 done

--- a/build/lin.sh
+++ b/build/lin.sh
@@ -144,7 +144,7 @@ version_latest() {
     VERSION_SELECTOR="versions"
   fi
   if [[ "$3" == *"/"* ]]; then
-    VERSION_LATEST=$($CURL $GITHUB_AUTH_HEADER "https://api.github.com/repos/$3/tags" | jq -j ".[0].name" | tr -d 'vV')
+    VERSION_LATEST=$(git ls-remote --tags --refs https://github.com/$3.git | sort -t'/' -k3 -V | awk -F'/' 'END{print $3}' | tr -d 'vV')
   else
     VERSION_LATEST=$($CURL "https://release-monitoring.org/api/v2/versions/?project_id=$3" | jq -j ".$VERSION_SELECTOR[0]" | tr '_' '.')
   fi

--- a/linuxmusl-arm64v8/Dockerfile
+++ b/linuxmusl-arm64v8/Dockerfile
@@ -19,6 +19,7 @@ RUN \
     brotli \
     build-base \
     cmake \
+    coreutils \
     curl \
     findutils \
     git \

--- a/linuxmusl-x64/Dockerfile
+++ b/linuxmusl-x64/Dockerfile
@@ -19,6 +19,7 @@ RUN \
     brotli \
     build-base \
     cmake \
+    coreutils \
     curl \
     findutils \
     git \


### PR DESCRIPTION
Using the `GITHUB_TOKEN` secret didn't work, since that access token
is scoped to the repository running the workflow. So, retrieving tags
from other repositories might still exceed the rate limit of GitHub's
Rest API.