### PR TITLE
arm64v8: prefer latest stable version of Rust

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -185,7 +185,7 @@ if [ "$ALL_AT_VERSION_LATEST" = "false" ]; then exit 1; fi
 
 if [ "$DARWIN" = true ]; then
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-    | sh -s -- -y --no-modify-path --profile minimal ${DARWIN_ARM:+--default-toolchain nightly}
+    | sh -s -- -y --no-modify-path --profile minimal
   if [ "$DARWIN_ARM" = true ]; then
     ${CARGO_HOME}/bin/rustup target add aarch64-apple-darwin
   fi

--- a/linux-arm64v8/Dockerfile
+++ b/linux-arm64v8/Dockerfile
@@ -32,7 +32,6 @@ RUN \
   curl https://sh.rustup.rs -sSf | sh -s -- -y \
     --no-modify-path \
     --profile minimal \
-    --default-toolchain nightly \
     && \
   rustup target add aarch64-unknown-linux-gnu && \
   ln -s /usr/bin/cmake3 /usr/bin/cmake && \

--- a/linuxmusl-arm64v8/Dockerfile
+++ b/linuxmusl-arm64v8/Dockerfile
@@ -44,7 +44,6 @@ RUN \
   curl https://sh.rustup.rs -sSf | sh -s -- -y \
     --no-modify-path \
     --profile minimal \
-    --default-toolchain nightly \
     && \
   rustup target add aarch64-unknown-linux-musl && \
   pip3 install meson


### PR DESCRIPTION
The underlying issue (#109) should be fixed with compiler-builtins
v0.1.55, available in Rust 1.59.0.