### PR TITLE
linux-armv{7,6}: remove `--allow-multiple-definition` linker flag

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -83,12 +83,6 @@ export CARGO_PROFILE_RELEASE_LTO=true
 export CARGO_PROFILE_RELEASE_OPT_LEVEL=z
 export CARGO_PROFILE_RELEASE_PANIC=abort
 
-# Workaround for https://github.com/rust-lang/compiler-builtins/issues/353
-# (applies only to ARMv6 and ARMv7)
-if [[ $PLATFORM == "linux-armv"* ]]; then
-  export LDFLAGS+=" -Wl,--allow-multiple-definition"
-fi
-
 # We don't want to use any native libraries, so unset PKG_CONFIG_PATH
 unset PKG_CONFIG_PATH
 


### PR DESCRIPTION
This should be fixed with compiler-builtins v0.1.69, available in
Rust 1.60.0.