### PR TITLE
glib: update patch

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -211,8 +211,8 @@ make install-strip
 mkdir ${DEPS}/glib
 $CURL https://download.gnome.org/sources/glib/$(without_patch $VERSION_GLIB)/glib-${VERSION_GLIB}.tar.xz | tar xJC ${DEPS}/glib --strip-components=1
 cd ${DEPS}/glib
-if [ "${PLATFORM%-*}" == "linuxmusl" ] || [ "$DARWIN" = true ]; then
-  $CURL https://gist.github.com/kleisauke/f6dcbf02a9aa43fd582272c3d815e7a8/raw/62c92abbca60e98ebdf289e456d034d6c20e607a/glib-proxy-libintl.patch | patch -p1
+if [ "$DARWIN" = true ]; then
+  $CURL https://gist.github.com/kleisauke/f6dcbf02a9aa43fd582272c3d815e7a8/raw/7d0e8324ad6c918978337bb6d180a93e01426845/glib-proxy-libintl.patch | patch -p1
 fi
 $CURL https://gist.githubusercontent.com/lovell/7e0ce65249b951d5be400fb275de3924/raw/1a833ef4263271d299587524198b024eb5cc4f34/glib-without-gregex.patch | patch -p1
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \

--- a/build/lin.sh
+++ b/build/lin.sh
@@ -186,6 +186,9 @@ if [ "$DARWIN" = true ]; then
 fi
 
 if [ "${PLATFORM%-*}" == "linuxmusl" ] || [ "$DARWIN" = true ]; then
+  # musl includes support for gettext by default, but since we have libintl installed, it favors that.
+  # macOS requires the standalone intl support library of gettext, since it's not provided by libc.
+  # In both cases: we use a stub version of gettext instead, since we don't need any of the i18n features.
   mkdir ${DEPS}/proxy-libintl
   $CURL https://github.com/frida/proxy-libintl/archive/${VERSION_PROXY_LIBINTL}.tar.gz | tar xzC ${DEPS}/proxy-libintl --strip-components=1
   cd ${DEPS}/proxy-libintl


### PR DESCRIPTION
This patch needed to be updated after https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2734.

It seems that it is now only needed for macOS, so remove the `linuxmusl` condition.