### PR TITLE
macOS: remove redundant system libraries link

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -52,9 +52,7 @@ if [ "$LINUX" = true ]; then
   export LDFLAGS+=" -Wl,--gc-sections -Wl,-rpath='\$\$ORIGIN/'"
 fi
 
-# On macOS, we need to explicitly link against the system libraries
 if [ "$DARWIN" = true ]; then
-  export LDFLAGS+=" -framework CoreServices -framework CoreFoundation -framework Foundation -framework AppKit"
   # Local rust installation
   export CARGO_HOME="${DEPS}/cargo"
   export RUSTUP_HOME="${DEPS}/rustup"


### PR DESCRIPTION
This became redundant after https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2413.