### PR TITLE
Re-add gperf dependency in Docker containers

### DIFF
--- a/linux-arm64v8/Dockerfile
+++ b/linux-arm64v8/Dockerfile
@@ -21,6 +21,7 @@ RUN \
     # FIXME: Update to devtoolset-11, see: https://bugs.centos.org/view.php?id=18393
     devtoolset-10-gcc \
     devtoolset-10-gcc-c++ \
+    gperf \
     jq \
     nasm \
     python3 \

--- a/linux-armv6/Dockerfile
+++ b/linux-armv6/Dockerfile
@@ -23,6 +23,7 @@ RUN \
     cmake \
     gettext \
     git \
+    gperf \
     jq \
     libtool \
     nasm \

--- a/linux-armv7/Dockerfile
+++ b/linux-armv7/Dockerfile
@@ -24,6 +24,7 @@ RUN \
     crossbuild-essential-armhf \
     gettext \
     git \
+    gperf \
     jq \
     libtool \
     nasm \

--- a/linux-x64/Dockerfile
+++ b/linux-x64/Dockerfile
@@ -20,6 +20,7 @@ RUN \
     cmake3 \
     devtoolset-11-gcc \
     devtoolset-11-gcc-c++ \
+    gperf \
     jq \
     nasm \
     ninja-build \

--- a/linuxmusl-arm64v8/Dockerfile
+++ b/linuxmusl-arm64v8/Dockerfile
@@ -23,6 +23,7 @@ RUN \
     curl \
     findutils \
     git \
+    gperf \
     jq \
     libtool \
     linux-headers \

--- a/linuxmusl-x64/Dockerfile
+++ b/linuxmusl-x64/Dockerfile
@@ -23,6 +23,7 @@ RUN \
     curl \
     findutils \
     git \
+    gperf \
     jq \
     libtool \
     linux-headers \


### PR DESCRIPTION
This was removed in commit 3e4fd28, but it's still required by Fontconfig.