### PR TITLE
macOS: remove version requirement for Meson

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Install dependencies (macOS)
       run: |
-        pip3 install meson!=0.63.1 ninja
+        pip3 install meson ninja
         brew update
         brew install advancecomp automake brotli nasm pkg-config
       if: contains(matrix.platform, 'darwin')


### PR DESCRIPTION
Skipping this version is now implicitly done since Meson 0.63.2
was released, which reverted the commit that caused this linker
failure.

See: https://github.com/mesonbuild/meson/commit/0e0dbf7e35f1e368090682bfd4818589d3c64d6e