### PR TITLE
Linux x64: align with v2 standard microarchitecture

### DIFF
--- a/linux-x64/Dockerfile
+++ b/linux-x64/Dockerfile
@@ -36,7 +36,7 @@ RUN \
 ENV \
   PKG_CONFIG="pkg-config --static" \
   PLATFORM="linux-x64" \
-  FLAGS="-march=westmere" \
+  FLAGS="-march=x86-64-v2 -mtune=nehalem" \
   MESON="--cross-file=/root/meson.ini"
 
 COPY Toolchain.cmake /root/

--- a/linuxmusl-x64/Dockerfile
+++ b/linuxmusl-x64/Dockerfile
@@ -44,7 +44,7 @@ RUN \
 ENV \
   PKG_CONFIG="pkg-config --static" \
   PLATFORM="linuxmusl-x64" \
-  FLAGS="-march=westmere"
+  FLAGS="-march=nehalem"
 
 # Musl defaults to static libs but we need them to be dynamic for host toolchain.
 # The toolchain will produce static libs by default.


### PR DESCRIPTION
The use of `-march=x86-64-v2` requires gcc 11, so this uses the almost-equivalent `-march=nehalem` with gcc 9 on Alpine.

I checked the zlib-ng source code and it compiles and includes functions for all common x64 intrinsics and uses runtime-dispatch, so will still take advantage of PCMUL intrinsics on newer hardware.

There appears to be a small ~4Kb increase in binary size due to this change.

Before:
```
17104592 libvips-cpp.so.42.15.0
```
After:
```
17108688 libvips-cpp.so.42.15.0
```

Fixes #153