### PR TITLE
win32: upgrade Docker container to Debian 11 (bullseye)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -77,7 +77,7 @@ if ! [ -x "$(command -v docker)" ]; then
 fi
 
 # Update base images
-for baseimage in centos:7 debian:buster debian:bullseye alpine:3.12; do
+for baseimage in alpine:3.12 centos:7 debian:bullseye debian:buster; do
   docker pull $baseimage
 done
 

--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 LABEL maintainer="Lovell Fuller <npm@lovell.info>"
 
 # Create Debian-based container suitable for post-processing Windows binaries


### PR DESCRIPTION
This container is used only for post-processing Windows binaries,
so we can safely bump to Debian 11 (bullseye).

The Linux ARMv7-A and ARMv6 containers still require Debian 10
(buster) to avoid a glibc version bump in the resulting binaries.