### PR TITLE
Meson: install only a subset of the installable files

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -188,8 +188,7 @@ if [ "${PLATFORM%-*}" == "linuxmusl" ] || [ "$DARWIN" = true ]; then
   $CURL https://github.com/frida/proxy-libintl/archive/${VERSION_PROXY_LIBINTL}.tar.gz | tar xzC ${DEPS}/proxy-libintl --strip-components=1
   cd ${DEPS}/proxy-libintl
   meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON}
-  ninja -C _build
-  ninja -C _build install
+  meson install -C _build --tag devel
 fi
 
 mkdir ${DEPS}/zlib-ng
@@ -220,8 +219,8 @@ if [ "$LINUX" = true ]; then
 fi
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   --force-fallback-for=gvdb -Dnls=disabled -Dtests=false -Dinstalled_tests=false -Dlibmount=disabled -Dlibelf=disabled ${DARWIN:+-Dbsymbolic_functions=false}
-ninja -C _build
-ninja -C _build install
+# bin-devel is needed for glib-compile-resources, as required by gdk-pixbuf
+meson install -C _build --tag bin-devel,devel
 
 mkdir ${DEPS}/xml2
 $CURL https://download.gnome.org/sources/libxml2/$(without_patch $VERSION_XML2)/libxml2-${VERSION_XML2}.tar.xz | tar xJC ${DEPS}/xml2 --strip-components=1
@@ -292,15 +291,13 @@ $CURL https://github.com/randy408/libspng/archive/v${VERSION_SPNG}.tar.gz | tar 
 cd ${DEPS}/spng
 CFLAGS="${CFLAGS} -O3" meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Dstatic_zlib=true
-ninja -C _build
-ninja -C _build install
+meson install -C _build --tag devel
 
 mkdir ${DEPS}/imagequant
 $CURL https://github.com/lovell/libimagequant/archive/v${VERSION_IMAGEQUANT}.tar.gz | tar xzC ${DEPS}/imagequant --strip-components=1
 cd ${DEPS}/imagequant
 CFLAGS="${CFLAGS} -O3" meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON}
-ninja -C _build
-ninja -C _build install
+meson install -C _build --tag devel
 
 mkdir ${DEPS}/webp
 $CURL https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${VERSION_WEBP}.tar.gz | tar xzC ${DEPS}/webp --strip-components=1
@@ -326,8 +323,7 @@ if [ "$PLATFORM" == "darwin-x64" ]; then
 fi
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Dorc-test=disabled -Dbenchmarks=disabled -Dexamples=disabled -Dgtk_doc=disabled -Dtests=disabled -Dtools=disabled
-ninja -C _build
-ninja -C _build install
+meson install -C _build --tag devel
 
 mkdir ${DEPS}/gdkpixbuf
 $CURL https://download.gnome.org/sources/gdk-pixbuf/$(without_patch $VERSION_GDKPIXBUF)/gdk-pixbuf-${VERSION_GDKPIXBUF}.tar.xz | tar xJC ${DEPS}/gdkpixbuf --strip-components=1
@@ -346,8 +342,7 @@ sed -i'.bak' "/loaders_cache = custom/{N;N;N;N;N;N;N;N;N;c\\
 }" gdk-pixbuf/meson.build
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Dtiff=disabled -Dintrospection=disabled -Dtests=false -Dinstalled_tests=false -Dgio_sniffing=false -Dman=false -Dbuiltin_loaders=png,jpeg
-ninja -C _build
-ninja -C _build install
+meson install -C _build --tag devel
 # Include libjpeg and libpng as a dependency of gdk-pixbuf, see: https://gitlab.gnome.org/GNOME/gdk-pixbuf/merge_requests/50
 sed -i'.bak' "s/^\(Requires:.*\)/\1 libjpeg, libpng16/" ${TARGET}/lib/pkgconfig/gdk-pixbuf-2.0.pc
 
@@ -356,8 +351,7 @@ $CURL https://download.savannah.gnu.org/releases/freetype/freetype-${VERSION_FRE
 cd ${DEPS}/freetype
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Dzlib=enabled -Dpng=disabled -Dharfbuzz=disabled -Dbrotli=disabled -Dbzip2=disabled
-ninja -C _build
-ninja -C _build install
+meson install -C _build --tag devel
 
 mkdir ${DEPS}/expat
 $CURL https://github.com/libexpat/libexpat/releases/download/R_${VERSION_EXPAT//./_}/expat-${VERSION_EXPAT}.tar.xz | tar xJC ${DEPS}/expat --strip-components=1
@@ -373,8 +367,7 @@ cd ${DEPS}/fontconfig
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Dcache-build=disabled -Ddoc=disabled -Dnls=disabled -Dtests=disabled -Dtools=disabled \
   ${LINUX:+--sysconfdir=/etc} ${DARWIN:+--sysconfdir=/usr/local/etc}
-ninja -C _build
-ninja -C _build install
+meson install -C _build --tag devel
 
 mkdir ${DEPS}/harfbuzz
 $CURL https://github.com/harfbuzz/harfbuzz/archive/${VERSION_HARFBUZZ}.tar.gz | tar xzC ${DEPS}/harfbuzz --strip-components=1
@@ -383,8 +376,7 @@ cd ${DEPS}/harfbuzz
 sed -i'.bak' "/subdir('util')/d" meson.build
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Dgobject=disabled -Dicu=disabled -Dtests=disabled -Dintrospection=disabled -Ddocs=disabled -Dbenchmark=disabled ${DARWIN:+-Dcoretext=enabled}
-ninja -C _build
-ninja -C _build install
+meson install -C _build --tag devel
 
 mkdir ${DEPS}/pixman
 $CURL https://cairographics.org/releases/pixman-${VERSION_PIXMAN}.tar.gz | tar xzC ${DEPS}/pixman --strip-components=1
@@ -392,8 +384,7 @@ cd ${DEPS}/pixman
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Dlibpng=disabled -Diwmmxt=disabled -Dgtk=disabled -Dopenmp=disabled -Dtests=disabled \
   ${DARWIN_ARM:+-Da64-neon=disabled}
-ninja -C _build
-ninja -C _build install
+meson install -C _build --tag devel
 
 mkdir ${DEPS}/cairo
 $CURL https://gitlab.freedesktop.org/cairo/cairo/-/archive/${VERSION_CAIRO}/cairo-${VERSION_CAIRO}.tar.bz2 | tar xjC ${DEPS}/cairo --strip-components=1
@@ -401,16 +392,14 @@ cd ${DEPS}/cairo
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   ${LINUX:+-Dquartz=disabled} ${DARWIN:+-Dquartz=enabled} -Dxcb=disabled -Dxlib=disabled -Dzlib=disabled \
   -Dtests=disabled -Dspectre=disabled -Dsymbol-lookup=disabled
-ninja -C _build
-ninja -C _build install
+meson install -C _build --tag devel
 
 mkdir ${DEPS}/fribidi
 $CURL https://github.com/fribidi/fribidi/releases/download/v${VERSION_FRIBIDI}/fribidi-${VERSION_FRIBIDI}.tar.xz | tar xJC ${DEPS}/fribidi --strip-components=1
 cd ${DEPS}/fribidi
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Ddocs=false -Dbin=false -Dtests=false
-ninja -C _build
-ninja -C _build install
+meson install -C _build --tag devel
 
 mkdir ${DEPS}/pango
 $CURL https://download.gnome.org/sources/pango/$(without_patch $VERSION_PANGO)/pango-${VERSION_PANGO}.tar.xz | tar xJC ${DEPS}/pango --strip-components=1
@@ -419,8 +408,7 @@ cd ${DEPS}/pango
 sed -i'.bak' "/subdir('utils')/{N;N;N;d;}" meson.build
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Dgtk_doc=false -Dintrospection=disabled -Dfontconfig=enabled
-ninja -C _build
-ninja -C _build install
+meson install -C _build --tag devel
 
 mkdir ${DEPS}/svg
 $CURL https://download.gnome.org/sources/librsvg/$(without_patch $VERSION_SVG)/librsvg-${VERSION_SVG}.tar.xz | tar xJC ${DEPS}/svg --strip-components=1
@@ -442,8 +430,7 @@ $CURL https://github.com/dloebl/cgif/archive/V${VERSION_CGIF}.tar.gz | tar xzC $
 cd ${DEPS}/cgif
 CFLAGS="${CFLAGS} -O3" meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Dtests=false
-ninja -C _build
-ninja -C _build install
+meson install -C _build --tag devel
 
 mkdir ${DEPS}/vips
 $CURL https://github.com/libvips/libvips/releases/download/v${VERSION_VIPS}/vips-${VERSION_VIPS}.tar.gz | tar xzC ${DEPS}/vips --strip-components=1
@@ -471,8 +458,7 @@ CFLAGS="${CFLAGS} -O3" CXXFLAGS="${CXXFLAGS} -O3" meson setup _build --default-l
   -Dmagick=disabled -Dmatio=disabled -Dnifti=disabled -Dopenexr=disabled -Dopenjpeg=disabled -Dopenslide=disabled \
   -Dpdfium=disabled -Dpoppler=disabled -Dquantizr=disabled -Dppm=false -Danalyze=false -Dradiance=false \
   ${LINUX:+-Dcpp_link_args="$LDFLAGS -Wl,-Bsymbolic-functions -Wl,--version-script=$DEPS/vips/vips.map $EXCLUDE_LIBS"}
-ninja -C _build
-ninja -C _build install
+meson install -C _build --tag runtime,devel
 
 # Cleanup
 rm -rf ${TARGET}/lib/{pkgconfig,.libs,*.la,cmake}


### PR DESCRIPTION
Requires at least Meson 0.64.0.

See https://mesonbuild.com/Installing.html#installation-tags.

Marked this PR as draft due to these TODO items:
- [x] GLib requires MR https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2905 to ensure `glibconfig.h` is tagged as `devel`.
- [x] Meson requires a new release that includes:
  - [x] PR https://github.com/mesonbuild/meson/pull/10826 - to ensure `gnome.mkenums` installed files are tagged as `devel`.
  - [x] PR https://github.com/mesonbuild/meson/pull/10959 - to ensure `custom_target` tags are automatically guessed.
- [x] ~FreeType needs to bump the minimum required Meson version to 0.60 and tag [`ftoption.h`](https://gitlab.freedesktop.org/freetype/freetype/-/blob/33ceac2afc3608be2d12b3dece071a91e34c3062/meson.build#L356) as `devel`.~
  No longer needed with Meson 0.64.0.
- [x] ~FriBidi needs to bump the minimum required Meson version to 0.60 and tag [`fribidi-unicode-version.h`](https://github.com/fribidi/fribidi/blob/3585a81e625e5b35962bed11fdc99d54485048e0/gen.tab/meson.build#L39) as `devel`.~
  No longer needed with Meson 0.64.0.