### PR TITLE
macOS: install Meson and Ninja via Homebrew

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -41,9 +41,8 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          pip3 install meson ninja
           brew update
-          brew install advancecomp automake brotli nasm pkg-config
+          brew install advancecomp automake brotli meson nasm ninja pkg-config
       - name: Build ${{ matrix.platform }}
         id: build-release
         run: ./build.sh $(cat LIBVIPS_VERSION) ${{ matrix.platform }}


### PR DESCRIPTION
Since GitHub actions migrated the Python installation to a universal package, which no longer adds the pip3 site-packages to the `PATH`, see: https://github.com/actions/runner-images/issues/6496.