### PR TITLE
glib: remove slice allocator (via Alpine Linux patch)

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -213,6 +213,10 @@ if [ "$DARWIN" = true ]; then
   $CURL https://gist.github.com/kleisauke/f6dcbf02a9aa43fd582272c3d815e7a8/raw/75b1e06250bdb0df067be4a5db54df960f35c46d/glib-proxy-libintl.patch | patch -p1
 fi
 $CURL https://gist.github.com/kleisauke/284d685efa00908da99ea6afbaaf39ae/raw/ce7f85f337357555c3112b36d4b2753ae996f5ff/glib-without-gregex.patch | patch -p1
+if [ "$LINUX" = true ]; then
+  # use malloc rather than slice allocator https://gitlab.gnome.org/GNOME/glib/-/issues/1079
+  $CURL https://raw.githubusercontent.com/alpinelinux/aports/ba57357f7a7094d1ebf4542912661383bafcf348/main/glib/always-malloc.patch | patch -p1
+fi
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   --force-fallback-for=gvdb -Dnls=disabled -Dtests=false -Dinstalled_tests=false -Dlibmount=disabled -Dlibelf=disabled ${DARWIN:+-Dbsymbolic_functions=false}
 ninja -C _build


### PR DESCRIPTION
This patch, from Alpine Linux, is approximately equivalent to setting `G_SLICE=always-malloc` and goes further by removing all the unused code. This should help prevent segfaults/hangs on QEMU-based emulated/interpreted environments, amongst others.

(The default memory allocator included in Windows UCRT is, I think, still bad enough to warrant retaining glib's slice logic in the Windows binaries.)

Related:

https://github.com/lovell/sharp/issues/3082
https://github.com/lovell/sharp/issues/3448

https://gitlab.gnome.org/GNOME/glib/-/issues/1079
https://gitlab.com/qemu-project/qemu/-/issues/285
