### PR TITLE
Bump dep: glib

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -88,7 +88,7 @@ CURL="curl --silent --location --retry 3 --retry-max-time 30"
 # Dependency version numbers
 VERSION_ZLIB_NG=2.0.6
 VERSION_FFI=3.4.4
-VERSION_GLIB=2.74.1
+VERSION_GLIB=2.75.0
 VERSION_XML2=2.10.3
 VERSION_GSF=1.14.50
 VERSION_EXIF=0.6.24
@@ -212,7 +212,7 @@ cd ${DEPS}/glib
 if [ "$DARWIN" = true ]; then
   $CURL https://gist.github.com/kleisauke/f6dcbf02a9aa43fd582272c3d815e7a8/raw/75b1e06250bdb0df067be4a5db54df960f35c46d/glib-proxy-libintl.patch | patch -p1
 fi
-$CURL https://gist.github.com/kleisauke/284d685efa00908da99ea6afbaaf39ae/raw/af997aa5b6bdb27484c6d9f16d9255d79c86aa77/glib-without-gregex.patch | patch -p1
+$CURL https://gist.github.com/kleisauke/284d685efa00908da99ea6afbaaf39ae/raw/ce7f85f337357555c3112b36d4b2753ae996f5ff/glib-without-gregex.patch | patch -p1
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   --force-fallback-for=gvdb -Dnls=disabled -Dtests=false -Dinstalled_tests=false -Dlibmount=disabled -Dlibelf=disabled ${DARWIN:+-Dbsymbolic_functions=false}
 ninja -C _build

--- a/linuxmusl-arm64v8/meson.ini
+++ b/linuxmusl-arm64v8/meson.ini
@@ -14,5 +14,10 @@ strip = 'aarch64-linux-musl-strip'
 ranlib = 'aarch64-linux-musl-ranlib'
 pkgconfig = ['aarch64-linux-musl-pkg-config', '--static']
 
+# Ensure we disable the inotify backend in GIO
+# See: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2991#note_1592863
+[properties]
+has_function_inotify_init1 = false
+
 [built-in options]
 libdir = 'lib'

--- a/linuxmusl-x64/Dockerfile
+++ b/linuxmusl-x64/Dockerfile
@@ -44,7 +44,8 @@ RUN \
 ENV \
   PKG_CONFIG="pkg-config --static" \
   PLATFORM="linuxmusl-x64" \
-  FLAGS="-march=nehalem"
+  FLAGS="-march=nehalem" \
+  MESON="--cross-file=/root/meson.ini"
 
 # Musl defaults to static libs but we need them to be dynamic for host toolchain.
 # The toolchain will produce static libs by default.
@@ -52,3 +53,4 @@ ENV \
   RUSTFLAGS="-Ctarget-feature=-crt-static"
 
 COPY Toolchain.cmake /root/
+COPY meson.ini /root/

--- a/linuxmusl-x64/meson.ini
+++ b/linuxmusl-x64/meson.ini
@@ -1,0 +1,4 @@
+# Ensure we disable the inotify backend in GIO
+# See: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2991#note_1592863
+[properties]
+has_function_inotify_init1 = false


### PR DESCRIPTION
- Rebase `glib-without-gregex.patch`.
- Ensure we disable the inotify backend for musl.