### PR TITLE
Revert "macOS: install Meson and Ninja via Homebrew (#163)"

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -41,7 +41,8 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install advancecomp automake brotli meson nasm ninja pkg-config
+          pip3 install meson ninja
+          brew install advancecomp automake brotli nasm pkg-config
       - name: Build ${{ matrix.platform }}
         id: build-release
         run: ./build.sh $(cat LIBVIPS_VERSION) ${{ matrix.platform }}


### PR DESCRIPTION
This reverts commit 944fbd2d2cac8c1d4a5043c6b73af9ca27ea8d51 and avoids depending on Python from Homebrew. The mentioned GitHub actions runner issue in PR https://github.com/lovell/sharp-libvips/pull/163 is ~~probably~~ a duplicate of https://github.com/actions/runner-images/issues/6507, which was fixed with commit https://github.com/actions/runner-images/commit/f6632ff53b24db9705c5b15bf90dbf05cc3fe295 ~~, but not yet deployed at the time of writing~~.

~~This PR is marked as a draft until GitHub updates its macOS runner images. After that, we can drop the workaround added in commit 27703f95ce1a68cb24b52fd590afeba45a2fe746.~~