### PR TITLE
Remove Cargo build path prefixes from the binaries

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -79,6 +79,10 @@ export CARGO_PROFILE_RELEASE_LTO=true
 export CARGO_PROFILE_RELEASE_OPT_LEVEL=z
 export CARGO_PROFILE_RELEASE_PANIC=abort
 
+# Ensure Cargo build path prefixes are removed from the resulting binaries
+# https://reproducible-builds.org/docs/build-path/
+export RUSTFLAGS+=" --remap-path-prefix=$CARGO_HOME/registry/="
+
 # We don't want to use any native libraries, so unset PKG_CONFIG_PATH
 unset PKG_CONFIG_PATH
 


### PR DESCRIPTION
Noticed this while doing:
```console
$ mkdir linux-x64
$ curl -fsSL https://github.com/lovell/sharp-libvips/releases/download/v8.13.3/libvips-8.13.3-linux-x64.tar.gz | tar xzC linux-x64
$ strings linux-x64/lib/libvips-cpp.so.42 | grep -c "/usr/local/cargo/registry/"
32
$ mkdir darwin-x64
$ curl -fsSL https://github.com/lovell/sharp-libvips/releases/download/v8.13.3/libvips-8.13.3-darwin-x64.tar.gz | tar xzC darwin-x64
$ strings darwin-x64/lib/libvips-cpp.42.dylib | grep -c "/Users/runner/work/sharp-libvips/sharp-libvips/deps/cargo/registry"
33
```

With this PR, I see:
```console
$ strings libvips-8.14.1-linux-x64/lib/libvips-cpp.so.42 | grep -c "/usr/local/cargo/registry/"
0
```