### PR TITLE
glib: compile without macros (assert, checks)

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -220,7 +220,8 @@ if [ "$DARWIN" = true ]; then
 fi
 $CURL https://gist.github.com/kleisauke/284d685efa00908da99ea6afbaaf39ae/raw/21e4100bce7145e9137c4b4a6c612e7a0864e476/glib-without-gregex.patch | patch -p1
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
-  --force-fallback-for=gvdb -Dnls=disabled -Dtests=false -Dinstalled_tests=false -Dlibmount=disabled -Dlibelf=disabled ${DARWIN:+-Dbsymbolic_functions=false}
+  --force-fallback-for=gvdb -Dnls=disabled -Dtests=false -Dinstalled_tests=false -Dlibmount=disabled -Dlibelf=disabled \
+  -Dglib_assert=false -Dglib_checks=false ${DARWIN:+-Dbsymbolic_functions=false}
 # bin-devel is needed for glib-compile-resources, as required by gdk-pixbuf
 meson install -C _build --tag bin-devel,devel
 


### PR DESCRIPTION
These remove a bit more glib code than I was expecting, overall resulting in a ~2% smaller binary.

Before:
```
-rw-r--r-- 1 root root  5646586 Mar 28 15:33 libgio-2.0.a
-rw-r--r-- 1 root root  2458480 Mar 28 15:32 libglib-2.0.a
-rw-r--r-- 1 root root    20398 Mar 28 15:32 libgmodule-2.0.a
-rw-r--r-- 1 root root   839672 Mar 28 15:32 libgobject-2.0.a
-rw-r--r-- 1 root root     2846 Mar 28 15:32 libgthread-2.0.a
...
-rwxr-xr-x 1 root root 16428664 Mar 28 15:44 libvips-cpp.so.42.16.2
```
After:
```
-rw-r--r-- 1 root root  4623762 Mar 28 16:12 libgio-2.0.a
-rw-r--r-- 1 root root  1910144 Mar 28 16:11 libglib-2.0.a
-rw-r--r-- 1 root root    17462 Mar 28 16:11 libgmodule-2.0.a
-rw-r--r-- 1 root root   615152 Mar 28 16:11 libgobject-2.0.a
-rw-r--r-- 1 root root     2358 Mar 28 16:11 libgthread-2.0.a
...
-rwxr-xr-x 1 root root 16105080 Mar 28 16:22 libvips-cpp.so.42.16.2
```
Use of these compile-time flags aligns with wasm-vips:

https://github.com/kleisauke/wasm-vips/blob/d5be25a705759de07b7c2a4a1ecbf0aad11f5ef3/build.sh#L283
