### PR TITLE
Ensure zlib-ng is installed in `lib/`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,12 +54,12 @@ for flavour in darwin-x64 darwin-arm64v8; do
     export FLAGS="-fno-stack-check"
     # Prevent use of API newer than the deployment target
     export FLAGS+=" -Werror=unguarded-availability-new"
+    export MESON="--cross-file=$PWD/$PLATFORM/meson.ini"
 
     if [ $PLATFORM = "darwin-arm64v8" ]; then
       # ARM64 builds work via cross compilation from an x86_64 machine
       export CHOST="aarch64-apple-darwin"
       export FLAGS+=" -target arm64-apple-macos11"
-      export MESON="--cross-file=$PWD/$PLATFORM/meson.ini"
       # macOS 11 Big Sur is the first version to support ARM-based macs
       export MACOSX_DEPLOYMENT_TARGET="11.0"
       # Set SDKROOT to the latest SDK available

--- a/build/lin.sh
+++ b/build/lin.sh
@@ -454,9 +454,6 @@ if [ "$LINUX" = true ]; then
   # Localize the g_param_spec_types symbol to avoid collisions with shared libraries
   # See: https://github.com/lovell/sharp/issues/2535#issuecomment-766400693
   printf "{local:g_param_spec_types;};" > vips.map
-elif [ "$DARWIN" = true ]; then
-  # https://github.com/pybind/pybind11/issues/595
-  export STRIP="strip -x"
 fi
 # Disable building man pages, gettext po files, tools, and (fuzz-)tests
 sed -i'.bak' "/subdir('man')/{N;N;N;N;d;}" meson.build

--- a/build/lin.sh
+++ b/build/lin.sh
@@ -203,7 +203,7 @@ mkdir ${DEPS}/zlib-ng
 $CURL https://github.com/zlib-ng/zlib-ng/archive/${VERSION_ZLIB_NG}.tar.gz | tar xzC ${DEPS}/zlib-ng --strip-components=1
 cd ${DEPS}/zlib-ng
 CFLAGS="${CFLAGS} -O3" cmake -G"Unix Makefiles" \
-  -DCMAKE_TOOLCHAIN_FILE=${ROOT}/Toolchain.cmake -DCMAKE_INSTALL_PREFIX=${TARGET} -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_TOOLCHAIN_FILE=${ROOT}/Toolchain.cmake -DCMAKE_INSTALL_PREFIX=${TARGET} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=FALSE -DZLIB_COMPAT=TRUE
 make install/strip
 
@@ -246,6 +246,8 @@ CFLAGS="${CFLAGS} -O3" meson setup _build --default-library=static --buildtype=r
 meson install -C _build --tag devel
 
 mkdir ${DEPS}/aom
+# NASM >= 2.14 is required to build libaom 3.7.0, see:
+# https://gitlab.kitware.com/cmake/cmake/-/issues/12919
 if [[ "$(nasm -v)" == "NASM version 2.10"* ]]; then
   VERSION_AOM="3.6.1"
 fi

--- a/darwin-arm64v8/meson.ini
+++ b/darwin-arm64v8/meson.ini
@@ -10,3 +10,6 @@ cpp = 'clang++'
 objc = 'clang'
 objcpp = 'clang++'
 strip = ['strip', '-x']
+
+[built-in options]
+wrap_mode = 'nofallback'

--- a/darwin-x64/meson.ini
+++ b/darwin-x64/meson.ini
@@ -1,0 +1,2 @@
+[built-in options]
+wrap_mode = 'nofallback'

--- a/darwin-x64/meson.ini
+++ b/darwin-x64/meson.ini
@@ -1,2 +1,5 @@
+[binaries]
+strip = ['strip', '-x']
+
 [built-in options]
 wrap_mode = 'nofallback'

--- a/linux-arm64v8/meson.ini
+++ b/linux-arm64v8/meson.ini
@@ -4,3 +4,4 @@ pkgconfig = ['pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'
+wrap_mode = 'nofallback'

--- a/linux-armv6/meson.ini
+++ b/linux-armv6/meson.ini
@@ -16,3 +16,4 @@ pkgconfig = ['arm-linux-gnueabihf-pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'
+wrap_mode = 'nofallback'

--- a/linux-armv7/meson.ini
+++ b/linux-armv7/meson.ini
@@ -16,3 +16,4 @@ pkgconfig = ['arm-linux-gnueabihf-pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'
+wrap_mode = 'nofallback'

--- a/linux-x64/meson.ini
+++ b/linux-x64/meson.ini
@@ -4,3 +4,4 @@ pkgconfig = ['pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'
+wrap_mode = 'nofallback'

--- a/linuxmusl-arm64v8/meson.ini
+++ b/linuxmusl-arm64v8/meson.ini
@@ -21,3 +21,4 @@ has_function_inotify_init1 = false
 
 [built-in options]
 libdir = 'lib'
+wrap_mode = 'nofallback'

--- a/linuxmusl-x64/meson.ini
+++ b/linuxmusl-x64/meson.ini
@@ -6,3 +6,6 @@ pkgconfig = ['pkg-config', '--static']
 # See: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2991#note_1592863
 [properties]
 has_function_inotify_init1 = false
+
+[built-in options]
+wrap_mode = 'nofallback'


### PR DESCRIPTION
Otherwise, it might inadvertently end up in the `lib64/` directory, resulting in the use of zlib 1.2.11 as provided by GLib as fallback.

<details>
  <summary>Details</summary>

```
-- Installing: /target/lib64/libz.a
-- Installing: /target/include/zlib.h
-- Installing: /target/include/zlib_name_mangling.h
-- Installing: /target/include/zconf.h
-- Installing: /target/lib64/pkgconfig/zlib.pc

...

Run-time dependency zlib found: NO (tried pkgconfig, cmake and system)
Looking for a fallback subproject for the dependency zlib
Downloading zlib source from https://zlib.net/fossils/zlib-1.2.11.tar.gz
Downloading zlib patch from https://wrapdb.mesonbuild.com/v2/zlib_1.2.11-6/get_patch

Executing subproject zlib 

zlib| Project name: zlib
zlib| Project version: 1.2.11
zlib| C compiler for the host machine: cc (gcc 11.2.1 "cc (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9)")
zlib| C linker for the host machine: cc ld.bfd 2.36.1-1
zlib| C compiler for the build machine: cc (gcc 11.2.1 "cc (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9)")
zlib| C linker for the build machine: cc ld.bfd 2.36.1-1
zlib| Compiler for C supports arguments -Wno-implicit-fallthrough: YES
zlib| Compiler for C supports arguments -Wno-implicit-function-declaration: YES
zlib| Build targets in project: 1
zlib| Subproject zlib finished.

Dependency zlib from subproject subprojects/zlib-1.2.11 found: YES 1.2.11
```
</details>

This issue was known to affect the linux-x64 and linuxmusl-x64 targets.

Use the built-in `wrap-mode=nofallback` option in Meson to prevent any further regressions.