### PR TITLE
macOS: Remove unused functions at link time, ~1% smaller binaries

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -53,6 +53,8 @@ if [ "$LINUX" = true ]; then
 fi
 
 if [ "$DARWIN" = true ]; then
+  # Let macOS linker remove unused code
+  export LDFLAGS+=" -Wl,-dead_strip"
   # Local rust installation
   export CARGO_HOME="${DEPS}/cargo"
   export RUSTUP_HOME="${DEPS}/rustup"


### PR DESCRIPTION
Size of resultant `libvips-cpp.42.dylib` file:

```
ARM64
before: 15915032
after:  15748120

x64
before: 18524800
after:  18326416
```

A small but not insignificant improvement. 

I tried various compiler flags to get the linker to remove more, e.g. `-gfull`, but to no avail.

(As an aside, there's still a big difference between x64 and ARM64, the bulk of which I think is coming from the libaom runtime detection logic.)