### PR TITLE
hwy: ensure correct lib directory

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -321,7 +321,7 @@ if [ -z "$WITHOUT_HIGHWAY" ]; then
   $CURL https://github.com/google/highway/archive/${VERSION_HWY}.tar.gz | tar xzC ${DEPS}/hwy --strip-components=1
   cd ${DEPS}/hwy
   CFLAGS="${CFLAGS} -O3" CXXFLAGS="${CXXFLAGS} -O3" cmake -G"Unix Makefiles" \
-    -DCMAKE_TOOLCHAIN_FILE=${ROOT}/Toolchain.cmake -DCMAKE_INSTALL_PREFIX=${TARGET} -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_TOOLCHAIN_FILE=${ROOT}/Toolchain.cmake -DCMAKE_INSTALL_PREFIX=${TARGET} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=FALSE -DBUILD_TESTING=0 -DHWY_ENABLE_CONTRIB=0 -DHWY_ENABLE_EXAMPLES=0 -DHWY_ENABLE_TESTS=0
   make install/strip
 fi


### PR DESCRIPTION
Before:
```
2023-10-19T15:02:51.0232087Z -- Installing: /target/lib64/pkgconfig/libhwy.pc
2023-10-19T15:09:01.8740127Z     SIMD support with highway         : NO
```
After:
```
2023-10-19T18:43:41.1109738Z -- Installing: /target/lib/pkgconfig/libhwy.pc
2023-10-19T18:49:16.1614328Z     SIMD support with highway         : YES
```
Apologies for not spotting this earlier.