### PR TITLE
Add infrastructure to re-publish release tarballs as npm packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ libvips*
 *.log
 deps/
 target/
+npm/*/*
+!npm/*/package.json
+npm/img-sharp-libvips-*.tgz

--- a/README.md
+++ b/README.md
@@ -3,13 +3,8 @@
 libvips and its dependencies are provided as pre-compiled shared libraries
 for the most common operating systems and CPU architectures.
 
-During `npm install`, these binaries are fetched as tarballs from
-this repository via HTTPS and stored locally within `node_modules/sharp/vendor`.
-
-The base URL can be overridden using the
-`npm_config_sharp_libvips_binary_host` environment variable.
-
-https://sharp.pixelplumbing.com/install#custom-prebuilt-binaries
+These are [packaged](npm) and published to the npm registry under the
+[@img](https://www.npmjs.com/org/img) organisation.
 
 ## Creating a tarball
 

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@img/sharp-libvips-darwin-arm64",
+  "version": "0.0.3",
+  "description": "Prebuilt libvips and dependencies for use with sharp on macOS 64-bit ARM",
+  "author": "Lovell Fuller <npm@lovell.info>",
+  "homepage": "https://sharp.pixelplumbing.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lovell/sharp-libvips.git",
+    "directory": "npm/darwin-arm64"
+  },
+  "license": "LGPL-3.0-or-later",
+  "funding": {
+    "url": "https://opencollective.com/libvips"
+  },
+  "preferUnplugged": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "versions.json"
+  ],
+  "type": "commonjs",
+  "exports": {
+    "./lib": "./lib/index.js",
+    "./package": "./package.json",
+    "./versions": "./versions.json"
+  },
+  "engines": {
+    "npm": ">=9.6.5",
+    "yarn": ">=3.2.0",
+    "pnpm": ">=7.1.0",
+    "macos": ">=11"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@img/sharp-libvips-darwin-x64",
+  "version": "0.0.3",
+  "description": "Prebuilt libvips and dependencies for use with sharp on macOS x64",
+  "author": "Lovell Fuller <npm@lovell.info>",
+  "homepage": "https://sharp.pixelplumbing.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lovell/sharp-libvips.git",
+    "directory": "npm/darwin-x64"
+  },
+  "license": "LGPL-3.0-or-later",
+  "funding": {
+    "url": "https://opencollective.com/libvips"
+  },
+  "preferUnplugged": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "versions.json"
+  ],
+  "type": "commonjs",
+  "exports": {
+    "./lib": "./lib/index.js",
+    "./package": "./package.json",
+    "./versions": "./versions.json"
+  },
+  "engines": {
+    "npm": ">=9.6.5",
+    "yarn": ">=3.2.0",
+    "pnpm": ">=7.1.0",
+    "macos": ">=10.13"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/npm/dev/package.json
+++ b/npm/dev/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@img/sharp-libvips-dev",
+  "version": "0.0.3",
+  "description": "Header files and C++ sources for libvips and dependencies required when compiling sharp from source",
+  "author": "Lovell Fuller <npm@lovell.info>",
+  "homepage": "https://sharp.pixelplumbing.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lovell/sharp-libvips.git",
+    "directory": "npm/dev"
+  },
+  "license": "LGPL-3.0-or-later",
+  "funding": {
+    "url": "https://opencollective.com/libvips"
+  },
+  "preferUnplugged": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "include",
+    "cplusplus",
+    "versions.json"
+  ],
+  "type": "commonjs",
+  "exports": {
+    "./include": "./include/index.js",
+    "./cplusplus": "./cplusplus/index.js"
+  }
+}

--- a/npm/linux-arm/package.json
+++ b/npm/linux-arm/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@img/sharp-libvips-linux-arm",
+  "version": "0.0.3",
+  "description": "Prebuilt libvips and dependencies for use with sharp on Linux (glibc) 32-bit ARM",
+  "author": "Lovell Fuller <npm@lovell.info>",
+  "homepage": "https://sharp.pixelplumbing.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lovell/sharp-libvips.git",
+    "directory": "npm/linux-arm"
+  },
+  "license": "LGPL-3.0-or-later",
+  "funding": {
+    "url": "https://opencollective.com/libvips"
+  },
+  "preferUnplugged": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "versions.json"
+  ],
+  "exports": {
+    "./lib": "./lib/index.js",
+    "./package": "./package.json",
+    "./versions": "./versions.json"
+  },
+  "type": "commonjs",
+  "engines": {
+    "npm": ">=9.6.5",
+    "yarn": ">=3.2.0",
+    "pnpm": ">=7.1.0",
+    "glibc": ">=2.28"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "cpu": [
+    "arm"
+  ]
+}

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@img/sharp-libvips-linux-arm64",
+  "version": "0.0.3",
+  "description": "Prebuilt libvips and dependencies for use with sharp on Linux (glibc) 64-bit ARM",
+  "author": "Lovell Fuller <npm@lovell.info>",
+  "homepage": "https://sharp.pixelplumbing.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lovell/sharp-libvips.git",
+    "directory": "npm/linux-arm64"
+  },
+  "license": "LGPL-3.0-or-later",
+  "funding": {
+    "url": "https://opencollective.com/libvips"
+  },
+  "preferUnplugged": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "versions.json"
+  ],
+  "type": "commonjs",
+  "exports": {
+    "./lib": "./lib/index.js",
+    "./package": "./package.json",
+    "./versions": "./versions.json"
+  },
+  "engines": {
+    "npm": ">=9.6.5",
+    "yarn": ">=3.2.0",
+    "pnpm": ">=7.1.0",
+    "glibc": ">=2.26"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/npm/linux-s390x/package.json
+++ b/npm/linux-s390x/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@img/sharp-libvips-linux-s390x",
+  "version": "0.0.3",
+  "description": "Prebuilt libvips and dependencies for use with sharp on Linux (glibc) s390x",
+  "author": "Lovell Fuller <npm@lovell.info>",
+  "homepage": "https://sharp.pixelplumbing.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lovell/sharp-libvips.git",
+    "directory": "npm/linux-s390x"
+  },
+  "license": "LGPL-3.0-or-later",
+  "funding": {
+    "url": "https://opencollective.com/libvips"
+  },
+  "preferUnplugged": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "versions.json"
+  ],
+  "exports": {
+    "./lib": "./lib/index.js",
+    "./package": "./package.json",
+    "./versions": "./versions.json"
+  },
+  "type": "commonjs",
+  "engines": {
+    "npm": ">=9.6.5",
+    "yarn": ">=3.2.0",
+    "pnpm": ">=7.1.0",
+    "glibc": ">=2.28"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "cpu": [
+    "s390x"
+  ]
+}

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@img/sharp-libvips-linux-x64",
+  "version": "0.0.3",
+  "description": "Prebuilt libvips and dependencies for use with sharp on Linux (glibc) x64",
+  "author": "Lovell Fuller <npm@lovell.info>",
+  "homepage": "https://sharp.pixelplumbing.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lovell/sharp-libvips.git",
+    "directory": "npm/linux-x64"
+  },
+  "license": "LGPL-3.0-or-later",
+  "funding": {
+    "url": "https://opencollective.com/libvips"
+  },
+  "preferUnplugged": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "versions.json"
+  ],
+  "type": "commonjs",
+  "exports": {
+    "./lib": "./lib/index.js",
+    "./package": "./package.json",
+    "./versions": "./versions.json"
+  },
+  "engines": {
+    "npm": ">=9.6.5",
+    "yarn": ">=3.2.0",
+    "pnpm": ">=7.1.0",
+    "glibc": ">=2.26"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/npm/linuxmusl-arm64/package.json
+++ b/npm/linuxmusl-arm64/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@img/sharp-libvips-linuxmusl-arm64",
+  "version": "0.0.3",
+  "description": "Prebuilt libvips and dependencies for use with sharp on Linux (musl) 64-bit ARM",
+  "author": "Lovell Fuller <npm@lovell.info>",
+  "homepage": "https://sharp.pixelplumbing.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lovell/sharp-libvips.git",
+    "directory": "npm/linuxmusl-arm64"
+  },
+  "license": "LGPL-3.0-or-later",
+  "funding": {
+    "url": "https://opencollective.com/libvips"
+  },
+  "preferUnplugged": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "versions.json"
+  ],
+  "type": "commonjs",
+  "exports": {
+    "./lib": "./lib/index.js",
+    "./package": "./package.json",
+    "./versions": "./versions.json"
+  },
+  "engines": {
+    "npm": ">=9.6.5",
+    "yarn": ">=3.2.0",
+    "pnpm": ">=7.1.0",
+    "musl": ">=1.2.2"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/npm/linuxmusl-x64/package.json
+++ b/npm/linuxmusl-x64/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@img/sharp-libvips-linuxmusl-x64",
+  "version": "0.0.3",
+  "description": "Prebuilt libvips and dependencies for use with sharp on Linux (musl) x64",
+  "author": "Lovell Fuller <npm@lovell.info>",
+  "homepage": "https://sharp.pixelplumbing.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lovell/sharp-libvips.git",
+    "directory": "npm/linuxmusl-x64"
+  },
+  "license": "LGPL-3.0-or-later",
+  "funding": {
+    "url": "https://opencollective.com/libvips"
+  },
+  "preferUnplugged": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "versions.json"
+  ],
+  "type": "commonjs",
+  "exports": {
+    "./lib": "./lib/index.js",
+    "./package": "./package.json",
+    "./versions": "./versions.json"
+  },
+  "engines": {
+    "npm": ">=9.6.5",
+    "yarn": ">=3.2.0",
+    "pnpm": ">=7.1.0",
+    "musl": ">=1.2.2"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@img/sharp-libvips",
+  "version": "0.0.3",
+  "private": "true",
+  "workspaces": [
+    "dev",
+    "darwin-x64",
+    "darwin-arm64",
+    "linux-arm",
+    "linux-arm64",
+    "linuxmusl-arm64",
+    "linuxmusl-x64",
+    "linux-s390x",
+    "linux-x64",
+    "win32-ia32",
+    "win32-x64"
+  ]
+}

--- a/npm/populate.sh
+++ b/npm/populate.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -e
+
+LIBVIPS_VERSION=$(cat LIBVIPS_VERSION)
+CURL="curl --silent --location"
+
+download_extract() {
+  PLATFORM="$1"
+  PACKAGE="${1%v[68]}" # remove ARM version
+  echo "$PLATFORM -> $PACKAGE"
+  rm -rf "npm/$PACKAGE/include" "npm/$PACKAGE/lib"
+  $CURL \
+    "https://github.com/lovell/sharp-libvips/releases/download/v$LIBVIPS_VERSION/libvips-$LIBVIPS_VERSION-$PLATFORM.tar.gz" | \
+    tar xzC "npm/$PACKAGE" --exclude="platform.json"
+}
+
+download_cpp() {
+  $CURL \
+    --remote-name --output-dir "npm/dev/cplusplus" --create-dirs \
+    "https://raw.githubusercontent.com/libvips/libvips/v$LIBVIPS_VERSION/cplusplus/$1.cpp"
+}
+
+generate_readme() {
+  PACKAGE="$1"
+  jq -r '("# `" + .name + "`\n\n" + .description + ".\n")' "npm/$PACKAGE/package.json" > "npm/$PACKAGE/README.md"
+  echo "## Licensing" >> "npm/$PACKAGE/README.md"
+  cat "npm/$PACKAGE/THIRD-PARTY-NOTICES.md" | tail -n +2 >> "npm/$PACKAGE/README.md"
+}
+
+generate_index() {
+  PACKAGE="$1"
+  for dir in include lib cplusplus; do
+    if [ -d "npm/$PACKAGE/$dir" ]; then
+      echo "module.exports = __dirname;" > "npm/$PACKAGE/$dir/index.js"
+    fi
+  done
+}
+
+remove_unused() {
+  PACKAGE="$1"
+  if [ "$PACKAGE" != "dev" ]; then
+    rm -r "npm/$PACKAGE/include"
+  fi
+  rm "npm/$PACKAGE/THIRD-PARTY-NOTICES.md"
+}
+
+# Download and extract per-platform binaries
+PLATFORMS=$(ls platforms --ignore=*armv7 --ignore=win32*)
+for platform in $PLATFORMS; do
+  download_extract "$platform"
+done
+download_extract "win32-ia32"
+download_extract "win32-x64"
+
+# Common header and source files
+cp -r npm/linux-x64/{include,versions.json,THIRD-PARTY-NOTICES.md} npm/dev/
+find npm/dev/include/ -maxdepth 1 -type f -links +1 -delete
+for source in VConnection VError VImage VInterpolate VRegion vips-operators; do
+  download_cpp "$source"
+done;
+
+# Generate README files
+PACKAGES=$(jq -r '.workspaces[]' "npm/package.json")
+for package in $PACKAGES; do
+  generate_readme "$package"
+  generate_index "$package"
+  remove_unused "$package"
+done

--- a/npm/win32-ia32/package.json
+++ b/npm/win32-ia32/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@img/sharp-libvips-win32-ia32",
+  "version": "0.0.3",
+  "description": "Prebuilt libvips and dependencies for use with sharp on Windows x86",
+  "author": "Lovell Fuller <npm@lovell.info>",
+  "homepage": "https://sharp.pixelplumbing.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lovell/sharp-libvips.git",
+    "directory": "npm/win32-ia32"
+  },
+  "license": "LGPL-3.0-or-later",
+  "funding": {
+    "url": "https://opencollective.com/libvips"
+  },
+  "preferUnplugged": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "versions.json"
+  ],
+  "type": "commonjs",
+  "exports": {
+    "./lib": "./lib/index.js",
+    "./package": "./package.json",
+    "./versions": "./versions.json"
+  }
+}

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@img/sharp-libvips-win32-x64",
+  "version": "0.0.3",
+  "description": "Prebuilt libvips and dependencies for use with sharp on Windows x64",
+  "author": "Lovell Fuller <npm@lovell.info>",
+  "homepage": "https://sharp.pixelplumbing.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lovell/sharp-libvips.git",
+    "directory": "npm/win32-x64"
+  },
+  "license": "LGPL-3.0-or-later",
+  "funding": {
+    "url": "https://opencollective.com/libvips"
+  },
+  "preferUnplugged": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "versions.json"
+  ],
+  "type": "commonjs",
+  "exports": {
+    "./lib": "./lib/index.js",
+    "./package": "./package.json",
+    "./versions": "./versions.json"
+  }
+}


### PR DESCRIPTION
The packages these produced have all been tested with sharp - see https://github.com/lovell/sharp/actions/runs/6756293763

Once the use of these has settled I'd like to move to an approach where (signed) packages are published directly to npm during CI (rather than an intermediate GitHub release), but this can wait for a while - see https://github.com/lovell/sharp-libvips/issues/206