### PR TITLE
Bump deps: fontconfig, glib

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          pip3 install meson ninja
+          pip3 install meson ninja packaging
           brew install automake nasm pkg-config
       - name: Build ${{ matrix.platform }}
         id: build-release

--- a/build/lin.sh
+++ b/build/lin.sh
@@ -94,7 +94,7 @@ CURL="curl --silent --location --retry 3 --retry-max-time 30"
 # Dependency version numbers
 VERSION_ZLIB_NG=2.1.5
 VERSION_FFI=3.4.4
-VERSION_GLIB=2.78.3
+VERSION_GLIB=2.79.0
 VERSION_XML2=2.12.3
 VERSION_EXIF=0.6.24
 VERSION_LCMS2=2.16
@@ -110,7 +110,7 @@ VERSION_GDKPIXBUF=2.42.10
 VERSION_FREETYPE=2.13.2
 VERSION_EXPAT=2.5.0
 VERSION_ARCHIVE=3.7.2
-VERSION_FONTCONFIG=2.14.2
+VERSION_FONTCONFIG=2.15.0
 VERSION_HARFBUZZ=8.3.0
 VERSION_PIXMAN=0.42.2
 VERSION_CAIRO=1.18.0
@@ -219,10 +219,10 @@ make install-strip
 mkdir ${DEPS}/glib
 $CURL https://download.gnome.org/sources/glib/$(without_patch $VERSION_GLIB)/glib-${VERSION_GLIB}.tar.xz | tar xJC ${DEPS}/glib --strip-components=1
 cd ${DEPS}/glib
-$CURL https://gist.githubusercontent.com/lovell/8d0de84a57dd10220cdeb8f64d7dd9ce/raw/1c0a5b5e1d5731bc1557df789e6d85b97f6a69dc/glib-without-gregex.patch | patch -p1
+$CURL https://gist.github.com/kleisauke/284d685efa00908da99ea6afbaaf39ae/raw/36e32c79e7962c5ea96cbb3f9c629e9145253e30/glib-without-gregex.patch | patch -p1
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
-  --force-fallback-for=gvdb -Dnls=disabled -Dtests=false -Dinstalled_tests=false -Dlibmount=disabled -Dlibelf=disabled \
-  -Dglib_assert=false -Dglib_checks=false ${DARWIN:+-Dbsymbolic_functions=false}
+  --force-fallback-for=gvdb -Dintrospection=disabled -Dnls=disabled -Dlibmount=disabled -Dlibelf=disabled \
+  -Dtests=false -Dglib_assert=false -Dglib_checks=false ${DARWIN:+-Dbsymbolic_functions=false}
 # bin-devel is needed for glib-compile-resources, as required by gdk-pixbuf
 meson install -C _build --tag bin-devel,devel
 

--- a/build/wasm.sh
+++ b/build/wasm.sh
@@ -12,7 +12,7 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 VERSION_VIPS="$1"
-VERSION_WASM_VIPS="${2:-ec19268}" # TODO: fetch latest wasm-vips commit as default
+VERSION_WASM_VIPS="${2:-HEAD}"
 
 DIR="wasm-vips-${VERSION_WASM_VIPS}"
 TAG="wasm-vips:${VERSION_WASM_VIPS}"

--- a/platforms/linux-arm64v8/Dockerfile
+++ b/platforms/linux-arm64v8/Dockerfile
@@ -49,7 +49,7 @@ RUN \
     --default-host aarch64-unknown-linux-gnu \
     && \
   ln -s /usr/bin/cmake3 /usr/bin/cmake && \
-  pip3 install meson ninja
+  pip3 install meson ninja packaging
 
 # Compiler settings
 ENV \

--- a/platforms/linux-armv6/Dockerfile
+++ b/platforms/linux-armv6/Dockerfile
@@ -26,6 +26,7 @@ RUN \
     libtool \
     ninja-build \
     pkg-config \
+    python3-packaging \
     python3-pip \
     && \
   mkdir /root/tools && \

--- a/platforms/linux-armv7/Dockerfile
+++ b/platforms/linux-armv7/Dockerfile
@@ -27,6 +27,7 @@ RUN \
     libtool \
     ninja-build \
     pkg-config \
+    python3-packaging \
     python3-pip \
     && \
   curl https://sh.rustup.rs -sSf | sh -s -- -y \

--- a/platforms/linux-s390x/Dockerfile
+++ b/platforms/linux-s390x/Dockerfile
@@ -27,6 +27,7 @@ RUN \
     libtool \
     ninja-build \
     pkg-config \
+    python3-packaging \
     python3-pip \
     && \
   curl https://sh.rustup.rs -sSf | sh -s -- -y \

--- a/platforms/linux-x64/Dockerfile
+++ b/platforms/linux-x64/Dockerfile
@@ -48,7 +48,7 @@ RUN \
     --profile minimal \
     && \
   ln -s /usr/bin/cmake3 /usr/bin/cmake && \
-  pip3 install meson ninja
+  pip3 install meson ninja packaging
 
 # Compiler settings
 ENV \

--- a/platforms/linuxmusl-arm64v8/Dockerfile
+++ b/platforms/linuxmusl-arm64v8/Dockerfile
@@ -28,6 +28,7 @@ RUN \
     linux-headers \
     ninja \
     pkgconf \
+    py3-packaging \
     py3-pip \
     python3 \
     && \

--- a/platforms/linuxmusl-x64/Dockerfile
+++ b/platforms/linuxmusl-x64/Dockerfile
@@ -29,6 +29,7 @@ RUN \
     nasm \
     ninja \
     pkgconf \
+    py3-packaging \
     py3-pip \
     python3 \
     && \


### PR DESCRIPTION
GLib 2.79.0 requires the `packaging` Python module, so add this dependency to the Docker images as well.
> ```md
>  * Bump Meson dependency to 1.2.0 and depend on Python `packaging` module
> ```
> _From: https://gitlab.gnome.org/GNOME/glib/-/blob/2.79.0/NEWS#L25_

While we're here, fetch the latest wasm-vips commit by default using the special `HEAD` reference. On Github, this will be the tip of the default branch.