### PR TITLE
Meson: replace deprecated "pkgconfig" entry in machine files

### DIFF
--- a/platforms/linux-arm64v8/meson.ini
+++ b/platforms/linux-arm64v8/meson.ini
@@ -1,6 +1,6 @@
 [binaries]
 strip = 'strip'
-pkgconfig = ['pkg-config', '--static']
+pkg-config = ['pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'

--- a/platforms/linux-armv6/meson.ini
+++ b/platforms/linux-armv6/meson.ini
@@ -12,7 +12,7 @@ nm = 'arm-rpi-linux-gnueabihf-gcc-nm'
 ld = 'arm-rpi-linux-gnueabihf-gcc-ld'
 strip = 'arm-rpi-linux-gnueabihf-strip'
 ranlib = 'arm-rpi-linux-gnueabihf-gcc-ranlib'
-pkgconfig = ['arm-linux-gnueabihf-pkg-config', '--static']
+pkg-config = ['arm-linux-gnueabihf-pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'

--- a/platforms/linux-armv7/meson.ini
+++ b/platforms/linux-armv7/meson.ini
@@ -12,7 +12,7 @@ nm = 'arm-linux-gnueabihf-gcc-nm'
 ld = 'arm-linux-gnueabihf-gcc-ld'
 strip = 'arm-linux-gnueabihf-strip'
 ranlib = 'arm-linux-gnueabihf-gcc-ranlib'
-pkgconfig = ['arm-linux-gnueabihf-pkg-config', '--static']
+pkg-config = ['arm-linux-gnueabihf-pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'

--- a/platforms/linux-s390x/meson.ini
+++ b/platforms/linux-s390x/meson.ini
@@ -12,7 +12,7 @@ nm = 's390x-linux-gnu-gcc-nm'
 ld = 's390x-linux-gnu-gcc-ld'
 strip = 's390x-linux-gnu-strip'
 ranlib = 's390x-linux-gnu-gcc-ranlib'
-pkgconfig = ['s390x-linux-gnu-pkg-config', '--static']
+pkg-config = ['s390x-linux-gnu-pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'

--- a/platforms/linux-x64/meson.ini
+++ b/platforms/linux-x64/meson.ini
@@ -1,6 +1,6 @@
 [binaries]
 strip = 'strip'
-pkgconfig = ['pkg-config', '--static']
+pkg-config = ['pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'

--- a/platforms/linuxmusl-arm64v8/meson.ini
+++ b/platforms/linuxmusl-arm64v8/meson.ini
@@ -12,7 +12,7 @@ nm = 'aarch64-linux-musl-nm'
 ld = 'aarch64-linux-musl-ld'
 strip = 'aarch64-linux-musl-strip'
 ranlib = 'aarch64-linux-musl-ranlib'
-pkgconfig = ['aarch64-linux-musl-pkg-config', '--static']
+pkg-config = ['aarch64-linux-musl-pkg-config', '--static']
 
 # Ensure we disable the inotify backend in GIO
 # See: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2991#note_1592863

--- a/platforms/linuxmusl-x64/meson.ini
+++ b/platforms/linuxmusl-x64/meson.ini
@@ -1,6 +1,6 @@
 [binaries]
 strip = 'strip'
-pkgconfig = ['pkg-config', '--static']
+pkg-config = ['pkg-config', '--static']
 
 # Ensure we disable the inotify backend in GIO
 # See: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2991#note_1592863


### PR DESCRIPTION
See:
https://mesonbuild.com/Release-notes-for-1-3-0.html#machine-files-pkgconfig-field-deprecated-and-replaced-by-pkgconfig

This should fix this deprecation warning:
```
DEPRECATION: "pkgconfig" entry is deprecated and should be replaced by "pkg-config"
```