### PR TITLE
CI: upgrade ARM64 runner and github-cli orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  github-cli: circleci/github-cli@1.0
+  github-cli: circleci/github-cli@2.0
 
 workflows:
   build:
@@ -23,4 +23,4 @@ jobs:
       - when:
           condition: <<pipeline.git.tag>>
           steps:
-            - run: gh release upload --repo lovell/sharp-libvips $CIRCLE_TAG *.tar.gz *.integrity
+            - run: gh release upload --repo "$(git config --get remote.origin.url)" $CIRCLE_TAG *.tar.gz *.integrity

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
   linux-arm64v8:
     resource_class: arm.medium
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:current
     steps:
       - checkout
       - github-cli/setup


### PR DESCRIPTION
See:
https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177
https://circleci.com/docs/using-arm/#ubuntu-2004---focal