### PR TITLE
Meson: uses system directories in machine files

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -379,8 +379,7 @@ mkdir ${DEPS}/fontconfig
 $CURL https://www.freedesktop.org/software/fontconfig/release/fontconfig-${VERSION_FONTCONFIG}.tar.xz | tar xJC ${DEPS}/fontconfig --strip-components=1
 cd ${DEPS}/fontconfig
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
-  -Dcache-build=disabled -Ddoc=disabled -Dnls=disabled -Dtests=disabled -Dtools=disabled \
-  ${LINUX:+--sysconfdir=/etc} ${DARWIN:+--sysconfdir=/usr/local/etc}
+  -Dcache-build=disabled -Ddoc=disabled -Dnls=disabled -Dtests=disabled -Dtools=disabled
 meson install -C _build --tag devel
 
 mkdir ${DEPS}/harfbuzz

--- a/platforms/darwin-arm64v8/meson.ini
+++ b/platforms/darwin-arm64v8/meson.ini
@@ -12,4 +12,8 @@ objcpp = 'clang++'
 strip = ['strip', '-x']
 
 [built-in options]
+datadir = '/usr/local/share'
+localedir = '/usr/local/share/locale'
+sysconfdir = '/usr/local/etc'
+localstatedir = '/usr/local/var'
 wrap_mode = 'nofallback'

--- a/platforms/darwin-x64/meson.ini
+++ b/platforms/darwin-x64/meson.ini
@@ -2,4 +2,8 @@
 strip = ['strip', '-x']
 
 [built-in options]
+datadir = '/usr/local/share'
+localedir = '/usr/local/share/locale'
+sysconfdir = '/usr/local/etc'
+localstatedir = '/usr/local/var'
 wrap_mode = 'nofallback'

--- a/platforms/linux-arm64v8/meson.ini
+++ b/platforms/linux-arm64v8/meson.ini
@@ -4,4 +4,8 @@ pkg-config = ['pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'
+datadir = '/usr/share'
+localedir = '/usr/share/locale'
+sysconfdir = '/etc'
+localstatedir = '/var'
 wrap_mode = 'nofallback'

--- a/platforms/linux-armv6/meson.ini
+++ b/platforms/linux-armv6/meson.ini
@@ -16,4 +16,8 @@ pkg-config = ['arm-linux-gnueabihf-pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'
+datadir = '/usr/share'
+localedir = '/usr/share/locale'
+sysconfdir = '/etc'
+localstatedir = '/var'
 wrap_mode = 'nofallback'

--- a/platforms/linux-armv7/meson.ini
+++ b/platforms/linux-armv7/meson.ini
@@ -16,4 +16,8 @@ pkg-config = ['arm-linux-gnueabihf-pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'
+datadir = '/usr/share'
+localedir = '/usr/share/locale'
+sysconfdir = '/etc'
+localstatedir = '/var'
 wrap_mode = 'nofallback'

--- a/platforms/linux-s390x/meson.ini
+++ b/platforms/linux-s390x/meson.ini
@@ -17,4 +17,8 @@ pkg-config = ['s390x-linux-gnu-pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'
+datadir = '/usr/share'
+localedir = '/usr/share/locale'
+sysconfdir = '/etc'
+localstatedir = '/var'
 wrap_mode = 'nofallback'

--- a/platforms/linux-x64/meson.ini
+++ b/platforms/linux-x64/meson.ini
@@ -4,4 +4,8 @@ pkg-config = ['pkg-config', '--static']
 
 [built-in options]
 libdir = 'lib'
+datadir = '/usr/share'
+localedir = '/usr/share/locale'
+sysconfdir = '/etc'
+localstatedir = '/var'
 wrap_mode = 'nofallback'

--- a/platforms/linuxmusl-arm64v8/meson.ini
+++ b/platforms/linuxmusl-arm64v8/meson.ini
@@ -21,4 +21,8 @@ has_function_inotify_init1 = false
 
 [built-in options]
 libdir = 'lib'
+datadir = '/usr/share'
+localedir = '/usr/share/locale'
+sysconfdir = '/etc'
+localstatedir = '/var'
 wrap_mode = 'nofallback'

--- a/platforms/linuxmusl-x64/meson.ini
+++ b/platforms/linuxmusl-x64/meson.ini
@@ -8,4 +8,8 @@ pkg-config = ['pkg-config', '--static']
 has_function_inotify_init1 = false
 
 [built-in options]
+datadir = '/usr/share'
+localedir = '/usr/share/locale'
+sysconfdir = '/etc'
+localstatedir = '/var'
 wrap_mode = 'nofallback'


### PR DESCRIPTION
Noticed this while doing:
```console
$ mkdir linux-x64
$ curl -fsSL https://github.com/lovell/sharp-libvips/releases/download/v8.15.2/libvips-8.15.2-linux-x64.tar.gz | tar xzC linux-x64
$ strings linux-x64/lib/libvips-cpp.so.42 | grep "/fontconfig"
  <dir prefix="xdg">fonts</dir>  <cachedir>/target/var/cache/fontconfig</cachedir>  <cachedir prefix="xdg">fontconfig</cachedir>  <include ignore_missing="yes">/etc/fonts/conf.d</include>  <include ignore_missing="yes" prefix="xdg">fontconfig/conf.d</include>  <include ignore_missing="yes" prefix="xdg">fontconfig/fonts.conf</include></fontconfig>
/target/share/fontconfig/conf.avail
/target/var/cache/fontconfig
/fontconfig
```

With this PR, I see:
```console
$ strings libvips-8.15.2-linux-x64/lib/libvips-cpp.so.42 | grep "/fontconfig"
  <dir prefix="xdg">fonts</dir>  <cachedir>/var/cache/fontconfig</cachedir>  <cachedir prefix="xdg">fontconfig</cachedir>  <include ignore_missing="yes">/etc/fonts/conf.d</include>  <include ignore_missing="yes" prefix="xdg">fontconfig/conf.d</include>  <include ignore_missing="yes" prefix="xdg">fontconfig/fonts.conf</include></fontconfig>
/usr/share/fontconfig/conf.avail
/var/cache/fontconfig
/fontconfig
```

And this during configuring Fontconfig:
```diff
   Paths
-    Cache directory            : /target/var/cache/fontconfig
-    Template directory         : /target/share/fontconfig/conf.avail
+    Cache directory            : /var/cache/fontconfig
+    Template directory         : /usr/share/fontconfig/conf.avail
     Base config directory      : /etc/fonts
     Config directory           : /etc/fonts/conf.d
-    XML directory              : /target/share/xml/fontconfig
+    XML directory              : /usr/share/xml/fontconfig
```