### PR TITLE
Build FreeType against libpng

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -353,7 +353,7 @@ build_freetype() {
   $CURL https://github.com/freetype/freetype/archive/VER-${VERSION_FREETYPE//./-}.tar.gz | tar xzC ${DEPS}/freetype --strip-components=1
   cd ${DEPS}/freetype
   meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
-    -Dzlib=enabled -Dpng=disabled -Dbrotli=disabled -Dbzip2=disabled "$@"
+    -Dzlib=enabled -Dpng=enabled -Dbrotli=disabled -Dbzip2=disabled "$@"
   meson install -C _build --tag devel
 }
 build_freetype -Dharfbuzz=disabled


### PR DESCRIPTION
It seems colored emoji glyphs are stored as PNG images in OpenType fonts, so compile FreeType with `-Dpng=enabled` to ensure that emoji can be rendered.

Tested by replacing `node_modules/@img/sharp-libvips-linux-x64/lib/libvips-cpp.so.42` with the produced binary and by doing:
```console
$ node -e "require('sharp')({text: { text: 'sharp is awesome! 🧩 ❤️', rgba: true }}).toFile('x.png')"
```
![x](https://github.com/lovell/sharp-libvips/assets/12746591/aae6262a-da86-493d-8632-03d7e580c37b)

Context: https://github.com/lovell/sharp/issues/3959.