### PR TITLE
Add libvips version number to shared library SONAME and filename

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
+# Remove patch version component
+without_patch() {
+  echo "${1%.[[:digit:]]*}"
+}
+# Remove prerelease suffix
+without_prerelease() {
+  echo "${1%-[[:alnum:]]*}"
+}
+
 # Environment / working directories
 case ${PLATFORM} in
   linux*)
@@ -9,7 +18,7 @@ case ${PLATFORM} in
     TARGET=/target
     PACKAGE=/packaging
     ROOT=/root
-    VIPS_CPP_DEP=libvips-cpp.so.42
+    VIPS_CPP_DEP=libvips-cpp.so.$(without_prerelease $VERSION_VIPS)
     ;;
   darwin*)
     DARWIN=true
@@ -17,7 +26,7 @@ case ${PLATFORM} in
     TARGET=$PWD/target
     PACKAGE=$PWD
     ROOT=$PWD/platforms/$PLATFORM
-    VIPS_CPP_DEP=libvips-cpp.42.dylib
+    VIPS_CPP_DEP=libvips-cpp.$(without_prerelease $VERSION_VIPS).dylib
     ;;
 esac
 
@@ -119,15 +128,6 @@ VERSION_RSVG=2.59.1
 VERSION_AOM=3.10.0
 VERSION_HEIF=1.18.2
 VERSION_CGIF=0.4.1
-
-# Remove patch version component
-without_patch() {
-  echo "${1%.[[:digit:]]*}"
-}
-# Remove prerelease suffix
-without_prerelease() {
-  echo "${1%-[[:alnum:]]*}"
-}
 
 # Check for newer versions
 # Skip by setting the VERSION_LATEST_REQUIRED environment variable to "false"
@@ -447,13 +447,15 @@ meson install -C _build --tag devel
 mkdir ${DEPS}/vips
 $CURL https://github.com/libvips/libvips/releases/download/v${VERSION_VIPS}/vips-${VERSION_VIPS}.tar.xz | tar xJC ${DEPS}/vips --strip-components=1
 cd ${DEPS}/vips
+# Use version number in SONAME
+$CURL https://gist.githubusercontent.com/lovell/313a6901e9db1bf285f2a1f1180499e4/raw/3988223c7dfa4d22745d9392034b0117abef1446/libvips-cpp-soversion.patch | patch -p1
 # Disable HBR support in heifsave
 $CURL https://github.com/libvips/build-win64-mxe/raw/v${VERSION_VIPS}/build/patches/vips-8-heifsave-disable-hbr-support.patch | patch -p1
-# Link libvips.so.42 statically into libvips-cpp.so.42
+# Link libvips.so statically into libvips-cpp.so
 sed -i'.bak' "s/library('vips'/static_&/" libvips/meson.build
 sed -i'.bak' "/version: library_version/{N;d;}" libvips/meson.build
 if [ "$LINUX" = true ]; then
-  # Ensure libvips-cpp.so.42 is linked with -z nodelete
+  # Ensure libvips-cpp.so is linked with -z nodelete
   sed -i'.bak' "/gnu_symbol_visibility: 'hidden',/a link_args: nodelete_link_args," cplusplus/meson.build
   # Ensure symbols from external libs (except for libglib-2.0.a and libgobject-2.0.a) are not exposed
   EXCLUDE_LIBS=$(find ${TARGET}/lib -maxdepth 1 -name '*.a' ! -name 'libglib-2.0.a' ! -name 'libgobject-2.0.a' -printf "-Wl,--exclude-libs=%f ")


### PR DESCRIPTION
This should help improve support for multiple versions of sharp that use differing versions of libvips running within the same process by ensuring `dlopen` accesses the relevant shared library.

Before:
```
lrwxrwxrwx 1 root root       17 Oct  8 15:05 libvips-cpp.so -> libvips-cpp.so.42
lrwxrwxrwx 1 root root       22 Oct  8 15:05 libvips-cpp.so.42 -> libvips-cpp.so.42.17.5
-rwxr-xr-x 1 root root 16313040 Oct  8 15:05 libvips-cpp.so.42.17.5
```
```
-rwxr-xr-x   1 runner  staff  18178880 Oct  8 15:13 libvips-cpp.42.dylib
lrwxr-xr-x   1 runner  staff        20 Oct  8 15:13 libvips-cpp.dylib -> libvips-cpp.42.dylib
```
After:
```
lrwxrwxrwx 1 root root       21 Oct  8 18:18 libvips-cpp.so -> libvips-cpp.so.8.15.5
-rwxr-xr-x 1 root root 16313040 Oct  8 18:18 libvips-cpp.so.8.15.5
```
```
-rwxr-xr-x   1 runner  staff  18178880 Oct  8 18:26 libvips-cpp.8.15.5.dylib
lrwxr-xr-x   1 runner  staff        24 Oct  8 18:26 libvips-cpp.dylib -> libvips-cpp.8.15.5.dylib
```

Relates to https://github.com/lovell/sharp/issues/4095