### PR TITLE
pixman: ARM64 intrinsics supported on Mach-O

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -384,7 +384,7 @@ $CURL https://cairographics.org/releases/pixman-${VERSION_PIXMAN}.tar.gz | tar x
 cd ${DEPS}/pixman
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Dlibpng=disabled -Dgtk=disabled -Dopenmp=disabled -Dtests=disabled -Ddemos=disabled \
-  ${DARWIN_ARM:+-Da64-neon=disabled}
+  ${WITHOUT_NEON:+-Da64-neon=disabled}
 meson install -C _build --tag devel
 
 mkdir ${DEPS}/cairo


### PR DESCRIPTION
Issue https://gitlab.freedesktop.org/pixman/pixman/-/issues/69 was resolved via https://gitlab.freedesktop.org/pixman/pixman/-/merge_requests/71.