### PR TITLE
Linux: ensure GLib's `g_print*()` functions wrap the system ones

### DIFF
--- a/platforms/linux-armv6/meson.ini
+++ b/platforms/linux-armv6/meson.ini
@@ -13,6 +13,12 @@ ld = 'arm-rpi-linux-gnueabihf-gcc-ld'
 strip = 'arm-rpi-linux-gnueabihf-strip'
 ranlib = 'arm-rpi-linux-gnueabihf-gcc-ranlib'
 
+[properties]
+# https://docs.gtk.org/glib/cross-compiling.html#cross-properties
+have_c99_vsnprintf = true
+have_c99_snprintf = true
+have_unix98_printf = true
+
 [built-in options]
 libdir = 'lib'
 datadir = '/usr/share'

--- a/platforms/linux-ppc64le/meson.ini
+++ b/platforms/linux-ppc64le/meson.ini
@@ -14,6 +14,12 @@ strip = 'powerpc64le-linux-gnu-strip'
 ranlib = 'powerpc64le-linux-gnu-gcc-ranlib'
 #exe_wrapper = 'qemu-ppc64le-static'
 
+[properties]
+# https://docs.gtk.org/glib/cross-compiling.html#cross-properties
+have_c99_vsnprintf = true
+have_c99_snprintf = true
+have_unix98_printf = true
+
 [built-in options]
 libdir = 'lib'
 datadir = '/usr/share'

--- a/platforms/linux-s390x/meson.ini
+++ b/platforms/linux-s390x/meson.ini
@@ -14,6 +14,12 @@ strip = 's390x-linux-gnu-strip'
 ranlib = 's390x-linux-gnu-gcc-ranlib'
 #exe_wrapper = 'qemu-s390x-static'
 
+[properties]
+# https://docs.gtk.org/glib/cross-compiling.html#cross-properties
+have_c99_vsnprintf = true
+have_c99_snprintf = true
+have_unix98_printf = true
+
 [built-in options]
 libdir = 'lib'
 datadir = '/usr/share'

--- a/platforms/linuxmusl-arm64v8/meson.ini
+++ b/platforms/linuxmusl-arm64v8/meson.ini
@@ -13,10 +13,14 @@ ld = 'aarch64-linux-musl-ld'
 strip = 'aarch64-linux-musl-strip'
 ranlib = 'aarch64-linux-musl-ranlib'
 
+[properties]
 # Ensure we disable the inotify backend in GIO
 # See: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2991#note_1592863
-[properties]
 has_function_inotify_init1 = false
+# https://docs.gtk.org/glib/cross-compiling.html#cross-properties
+have_c99_vsnprintf = true
+have_c99_snprintf = true
+have_unix98_printf = true
 
 [built-in options]
 libdir = 'lib'

--- a/platforms/linuxmusl-x64/meson.ini
+++ b/platforms/linuxmusl-x64/meson.ini
@@ -1,9 +1,9 @@
 [binaries]
 strip = 'strip'
 
+[properties]
 # Ensure we disable the inotify backend in GIO
 # See: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2991#note_1592863
-[properties]
 has_function_inotify_init1 = false
 
 [built-in options]


### PR DESCRIPTION
C99 `printf()` semantics are well-supported by these Linux cross-targets, avoids the need for gnulib compat functions.

An alternative is setting up QEMU when cross-compiling, as this functionality is gated by `meson.can_run_host_binaries()`, but this is a bit simpler.

Note: this is not needed for macOS due to:
https://github.com/GNOME/glib/blob/2.83.3/meson.build#L1204-L1212
(you can verify this by checking for the `GLIB_USING_SYSTEM_PRINTF` definition in `lib/glib-2.0/include/glibconfig.h`)

Windows binaries, where this was originally found, will be fixed via PR https://github.com/libvips/build-win64-mxe/pull/72 or work-in-progress commit https://github.com/libvips/build-win64-mxe/commit/ea91b64f9a56369b2abf2d2f224f91f2420f8337.