### PR TITLE
Bump dep: rsvg

### DIFF
--- a/build/lin.sh
+++ b/build/lin.sh
@@ -124,7 +124,7 @@ VERSION_PIXMAN=0.44.2
 VERSION_CAIRO=1.18.2
 VERSION_FRIBIDI=1.0.16
 VERSION_PANGO=1.56.1
-VERSION_RSVG=2.59.2
+VERSION_RSVG=2.59.90
 VERSION_AOM=3.12.0
 VERSION_HEIF=1.19.5
 VERSION_CGIF=0.5.0
@@ -173,7 +173,7 @@ version_latest "pixman" "$VERSION_PIXMAN" "3648"
 version_latest "cairo" "$VERSION_CAIRO" "247"
 version_latest "fribidi" "$VERSION_FRIBIDI" "857"
 version_latest "pango" "$VERSION_PANGO" "11783" "unstable"
-version_latest "rsvg" "$VERSION_RSVG" "5420"
+version_latest "rsvg" "$VERSION_RSVG" "5420" "unstable"
 version_latest "aom" "$VERSION_AOM" "17628"
 version_latest "heif" "$VERSION_HEIF" "64439"
 version_latest "cgif" "$VERSION_CGIF" "dloebl/cgif"
@@ -417,9 +417,10 @@ sed -i'.bak' "/image = /s/, \"gif\", \"webp\"//" rsvg/Cargo.toml
 sed -i'.bak' "/cairo-rs = /s/, \"pdf\", \"ps\"//" {librsvg-c,rsvg}/Cargo.toml
 # Skip build of rsvg-convert
 sed -i'.bak' "/subdir('rsvg_convert')/d" meson.build
-# Update and regenerate the lockfile for zune-jpeg
-# https://github.com/etemesi254/zune-image/pull/242
-cargo update zune-jpeg
+# https://gitlab.gnome.org/GNOME/librsvg/-/merge_requests/1066#note_2356762
+sed -i'.bak' "/^if host_system in \['windows'/s/, 'linux'//" meson.build
+# Regenerate the lockfile after making the above changes
+cargo update --workspace
 # Remove the --static flag from the PKG_CONFIG env since Rust does not
 # parse that correctly.
 PKG_CONFIG=${PKG_CONFIG/ --static/} meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \


### PR DESCRIPTION
Helps https://github.com/lovell/sharp/issues/1996; however, according to https://gitlab.gnome.org/GNOME/librsvg/-/merge_requests/1072, `dominant-baseline="middle"` may not be entirely accurate.