### PR TITLE
Publish Windows arm64 package to NPM

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -15,6 +15,7 @@
     "linux-s390x",
     "linux-x64",
     "win32-ia32",
-    "win32-x64"
+    "win32-x64",
+    "win32-arm64"
   ]
 }

--- a/npm/populate.sh
+++ b/npm/populate.sh
@@ -58,7 +58,7 @@ for platform in $PLATFORMS; do
 done
 download_extract "win32-ia32"
 download_extract "win32-x64"
-download_extract "win32-arm64"
+download_extract "win32-arm64v8"
 
 # Common header and source files
 cp -r npm/linux-x64/{include,versions.json,THIRD-PARTY-NOTICES.md} npm/dev/

--- a/npm/populate.sh
+++ b/npm/populate.sh
@@ -58,6 +58,7 @@ for platform in $PLATFORMS; do
 done
 download_extract "win32-ia32"
 download_extract "win32-x64"
+download_extract "win32-arm64"
 
 # Common header and source files
 cp -r npm/linux-x64/{include,versions.json,THIRD-PARTY-NOTICES.md} npm/dev/

--- a/npm/win32-arm64/package.json
+++ b/npm/win32-arm64/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@img/sharp-libvips-win32-arm64",
+  "version": "1.1.0",
+  "description": "Prebuilt libvips and dependencies for use with sharp on Windows arm64",
+  "author": "Lovell Fuller <npm@lovell.info>",
+  "homepage": "https://sharp.pixelplumbing.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lovell/sharp-libvips.git",
+    "directory": "npm/win32-arm64"
+  },
+  "license": "LGPL-3.0-or-later",
+  "funding": {
+    "url": "https://opencollective.com/libvips"
+  },
+  "preferUnplugged": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "versions.json"
+  ],
+  "type": "commonjs",
+  "exports": {
+    "./lib": "./lib/index.js",
+    "./package": "./package.json",
+    "./versions": "./versions.json"
+  }
+}


### PR DESCRIPTION
Windows ARM64 binaries are already being built. For example, the most recent [8.16.1 release](https://github.com/lovell/sharp-libvips/releases/tag/v8.16.1) already contains a `libvips-8.16.1-win32-arm64v8.tar.gz` file.

Let's start publishing the `@img/sharp-libvips-win32-arm64` NPM package to unblock https://github.com/lovell/sharp/pull/4375.

Closes https://github.com/lovell/sharp-libvips/issues/238