### PR TITLE
Temporarily pin meson to 1.7.2

### DIFF
--- a/platforms/linux-arm64v8/Dockerfile
+++ b/platforms/linux-arm64v8/Dockerfile
@@ -51,7 +51,7 @@ RUN \
     && \
   cargo install cargo-c --locked && \
   ln -s /usr/bin/cmake3 /usr/bin/cmake && \
-  pip3 install meson ninja packaging tomli
+  pip3 install meson==1.7.2 ninja packaging tomli
 
 # Compiler settings
 ENV \

--- a/platforms/linux-armv6/Dockerfile
+++ b/platforms/linux-armv6/Dockerfile
@@ -38,7 +38,7 @@ RUN \
     && \
   rustup target add arm-unknown-linux-gnueabihf && \
   cargo install cargo-c --locked && \
-  pip3 install meson tomli
+  pip3 install meson==1.7.2 tomli
 
 # Compiler settings
 ENV \

--- a/platforms/linux-ppc64le/Dockerfile
+++ b/platforms/linux-ppc64le/Dockerfile
@@ -36,7 +36,7 @@ RUN \
     && \
   rustup target add powerpc64le-unknown-linux-gnu && \
   cargo install cargo-c --locked && \
-  pip3 install meson tomli
+  pip3 install meson==1.7.2 tomli
 
 # Handy for debugging the compiled targets in Highway (hwy_list_targets)
 #RUN apt-get install -y qemu-user-static

--- a/platforms/linux-s390x/Dockerfile
+++ b/platforms/linux-s390x/Dockerfile
@@ -37,7 +37,7 @@ RUN \
     && \
   rustup target add s390x-unknown-linux-gnu && \
   cargo install cargo-c --locked && \
-  pip3 install meson tomli
+  pip3 install meson==1.7.2 tomli
 
 # Handy for debugging the compiled targets in Highway (hwy_list_targets)
 #RUN apt-get install -y qemu-user-static

--- a/platforms/linux-x64/Dockerfile
+++ b/platforms/linux-x64/Dockerfile
@@ -50,7 +50,7 @@ RUN \
     && \
   cargo install cargo-c --locked && \
   ln -s /usr/bin/cmake3 /usr/bin/cmake && \
-  pip3 install meson ninja packaging tomli
+  pip3 install meson==1.7.2 ninja packaging tomli
 
 # Compiler settings
 ENV \

--- a/platforms/linuxmusl-arm64v8/Dockerfile
+++ b/platforms/linuxmusl-arm64v8/Dockerfile
@@ -47,7 +47,7 @@ RUN \
     && \
   rustup target add aarch64-unknown-linux-musl && \
   cargo install cargo-c --locked && \
-  pip3 install meson
+  pip3 install meson==1.7.2
 
 # Compiler settings
 ENV \

--- a/platforms/linuxmusl-x64/Dockerfile
+++ b/platforms/linuxmusl-x64/Dockerfile
@@ -44,7 +44,7 @@ RUN \
     --profile minimal \
     && \
   cargo install cargo-c --locked && \
-  pip3 install meson
+  pip3 install meson==1.7.2
 
 # Compiler settings
 ENV \


### PR DESCRIPTION
Meson 1.8.1 still has a regression[^1] in how it handles the `CFLAGS` and `CXXFLAGS` environment variables when `c_link_args` or `cpp_link_args` are specified via the CLI.

[^1]: https://github.com/mesonbuild/meson/issues/14640