### PR TITLE
Ensure files are not placed outside install prefix

### DIFF
--- a/build/posix.sh
+++ b/build/posix.sh
@@ -276,6 +276,8 @@ make install-strip libarchive_man_MANS=
 mkdir ${DEPS}/fontconfig
 $CURL https://gitlab.freedesktop.org/fontconfig/fontconfig/-/archive/${VERSION_FONTCONFIG}/fontconfig-${VERSION_FONTCONFIG}.tar.gz | tar xzC ${DEPS}/fontconfig --strip-components=1
 cd ${DEPS}/fontconfig
+# Disable install of gettext files
+sed -i'.bak' "/subdir('its')/d" meson.build
 meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
   -Dcache-build=disabled -Ddoc=disabled -Dnls=disabled -Dtests=disabled -Dtools=disabled
 meson install -C _build --tag devel

--- a/build/posix.sh
+++ b/build/posix.sh
@@ -139,10 +139,10 @@ mkdir ${DEPS}/glib
 $CURL https://download.gnome.org/sources/glib/$(without_patch $VERSION_GLIB)/glib-${VERSION_GLIB}.tar.xz | tar xJC ${DEPS}/glib --strip-components=1
 cd ${DEPS}/glib
 $CURL https://gist.github.com/kleisauke/284d685efa00908da99ea6afbaaf39ae/raw/936a6b8013d07d358c6944cc5b5f0e27db707ace/glib-without-gregex.patch | patch -p1
-meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} ${MESON} \
+meson setup _build --default-library=static --buildtype=release --strip --prefix=${TARGET} --datadir=${TARGET}/share ${MESON} \
   --force-fallback-for=gvdb -Dintrospection=disabled -Dnls=disabled -Dlibmount=disabled -Dsysprof=disabled -Dlibelf=disabled \
   -Dtests=false -Dglib_assert=false -Dglib_checks=false -Dglib_debug=disabled ${DARWIN:+-Dbsymbolic_functions=false}
-# bin-devel is needed for glib-compile-resources
+# bin-devel is needed for glib-mkenums
 meson install -C _build --tag bin-devel,devel
 
 mkdir ${DEPS}/xml2

--- a/platforms/darwin-arm64v8/meson.ini
+++ b/platforms/darwin-arm64v8/meson.ini
@@ -2,4 +2,8 @@
 strip = ['strip', '-x']
 
 [built-in options]
+datadir = '/usr/local/share'
+localedir = '/usr/local/share/locale'
+sysconfdir = '/usr/local/etc'
+localstatedir = '/usr/local/var'
 wrap_mode = 'nofallback'

--- a/platforms/darwin-x64/meson.ini
+++ b/platforms/darwin-x64/meson.ini
@@ -2,4 +2,8 @@
 strip = ['strip', '-x']
 
 [built-in options]
+datadir = '/usr/local/share'
+localedir = '/usr/local/share/locale'
+sysconfdir = '/usr/local/etc'
+localstatedir = '/usr/local/var'
 wrap_mode = 'nofallback'


### PR DESCRIPTION
Commit ec75c960c6a20bfc5bef134ddf181023c8bf1ddf and 5c27d097dcc77136178bce492a5f7e83b96a4998 ensures that files are not placed outside the install prefix. This allow us to restore the directories removed in commit 27607130f3c98d9694155107989be31654ebe6dd, which are possibly(?) required by Fontconfig to locate system fonts.

Note: upstream PR https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4661 would prevent the `/target/share/locale` build path from being included in the binaries (context: https://github.com/lovell/sharp-libvips/pull/227#issuecomment-2016828471).