### PR TITLE
Use rust nightly on platforms where linker supports it

### DIFF
--- a/build/posix.sh
+++ b/build/posix.sh
@@ -106,7 +106,8 @@ CURL="curl --silent --location --retry 3 --retry-max-time 30"
 
 if [ "$DARWIN" = true ]; then
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-    | sh -s -- -y --no-modify-path --profile minimal
+    | sh -s -- -y --no-modify-path --profile minimal --default-toolchain nightly
+  export RUSTFLAGS+=" -Zlocation-detail=none -Zfmt-debug=none"
   CFLAGS= cargo install cargo-c --locked
 fi
 

--- a/platforms/linux-arm64v8/Dockerfile
+++ b/platforms/linux-arm64v8/Dockerfile
@@ -48,6 +48,7 @@ RUN \
     --no-modify-path \
     --profile minimal \
     --default-host aarch64-unknown-linux-gnu \
+    --default-toolchain nightly \
     && \
   cargo install cargo-c --locked && \
   ln -s /usr/bin/cmake3 /usr/bin/cmake && \
@@ -58,6 +59,7 @@ ENV \
   PKG_CONFIG="pkg-config --static" \
   PLATFORM="linux-arm64v8" \
   FLAGS="-march=armv8-a" \
+  RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" \
   MESON="--cross-file=/root/meson.ini"
 
 COPY Toolchain.cmake /root/

--- a/platforms/linux-armv6/Dockerfile
+++ b/platforms/linux-armv6/Dockerfile
@@ -35,8 +35,9 @@ RUN \
   curl https://sh.rustup.rs -sSf | sh -s -- -y \
     --no-modify-path \
     --profile minimal \
+    --target arm-unknown-linux-gnueabihf \
+    --default-toolchain nightly \
     && \
-  rustup target add arm-unknown-linux-gnueabihf && \
   cargo install cargo-c --locked && \
   pip3 install meson==1.7.2 tomli
 
@@ -47,6 +48,7 @@ ENV \
   CHOST="arm-rpi-linux-gnueabihf" \
   RUST_TARGET="arm-unknown-linux-gnueabihf" \
   FLAGS="-marm -mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" \
+  RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" \
   WITHOUT_NEON="true" \
   # Highway requires NEON (Armv7+)
   WITHOUT_HIGHWAY="true" \

--- a/platforms/linux-ppc64le/Dockerfile
+++ b/platforms/linux-ppc64le/Dockerfile
@@ -33,8 +33,9 @@ RUN \
   curl https://sh.rustup.rs -sSf | sh -s -- -y \
     --no-modify-path \
     --profile minimal \
+    --target powerpc64le-unknown-linux-gnu \
+    --default-toolchain nightly \
     && \
-  rustup target add powerpc64le-unknown-linux-gnu && \
   cargo install cargo-c --locked && \
   pip3 install meson==1.7.2 tomli
 
@@ -49,6 +50,7 @@ ENV \
   CHOST="powerpc64le-linux-gnu" \
   RUST_TARGET="powerpc64le-unknown-linux-gnu" \
   FLAGS="" \
+  RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" \
   MESON="--cross-file=/root/meson.ini"
 
 COPY Toolchain.cmake /root/

--- a/platforms/linux-riscv64/Dockerfile
+++ b/platforms/linux-riscv64/Dockerfile
@@ -35,8 +35,9 @@ RUN \
   curl https://sh.rustup.rs -sSf | sh -s -- -y \
     --no-modify-path \
     --profile minimal \
+    --target riscv64gc-unknown-linux-gnu \
+    --default-toolchain nightly \
     && \
-  rustup target add riscv64gc-unknown-linux-gnu && \
   cargo install cargo-c --locked && \
   pipx install meson==1.7.2
 
@@ -47,6 +48,7 @@ ENV \
   CHOST="riscv64-linux-gnu" \
   RUST_TARGET="riscv64gc-unknown-linux-gnu" \
   FLAGS="-march=rv64gc" \
+  RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" \
   WITHOUT_HIGHWAY="true" \
   MESON="--cross-file=/root/meson.ini"
 

--- a/platforms/linux-s390x/Dockerfile
+++ b/platforms/linux-s390x/Dockerfile
@@ -34,8 +34,9 @@ RUN \
   curl https://sh.rustup.rs -sSf | sh -s -- -y \
     --no-modify-path \
     --profile minimal \
+    --target s390x-unknown-linux-gnu \
+    --default-toolchain nightly \
     && \
-  rustup target add s390x-unknown-linux-gnu && \
   cargo install cargo-c --locked && \
   pip3 install meson==1.7.2 tomli
 
@@ -50,6 +51,7 @@ ENV \
   CHOST="s390x-linux-gnu" \
   RUST_TARGET="s390x-unknown-linux-gnu" \
   FLAGS="" \
+  RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" \
   # Highway supports IBMZ starting from IBM/Z14, which needs GCC 11 or
   # higher (i.e. Debian 12, glibc 2.36). Therefore, it should be disabled
   # for the time being.

--- a/platforms/linuxmusl-arm64v8/Dockerfile
+++ b/platforms/linuxmusl-arm64v8/Dockerfile
@@ -42,6 +42,7 @@ RUN \
     --no-modify-path \
     --profile minimal \
     --default-host aarch64-unknown-linux-musl \
+    --default-toolchain nightly \
     && \
   cargo install cargo-c --locked && \
   pip3 install meson==1.7.2
@@ -51,6 +52,7 @@ ENV \
   PKG_CONFIG="pkg-config --static" \
   PLATFORM="linuxmusl-arm64v8" \
   FLAGS="-march=armv8-a" \
+  RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" \
   MESON="--cross-file=/root/meson.ini"
 
 COPY Toolchain.cmake /root/

--- a/platforms/linuxmusl-x64/Dockerfile
+++ b/platforms/linuxmusl-x64/Dockerfile
@@ -42,6 +42,7 @@ RUN \
   curl https://sh.rustup.rs -sSf | sh -s -- -y \
     --no-modify-path \
     --profile minimal \
+    --default-toolchain nightly \
     && \
   cargo install cargo-c --locked && \
   pip3 install meson==1.7.2
@@ -51,6 +52,7 @@ ENV \
   PKG_CONFIG="pkg-config --static" \
   PLATFORM="linuxmusl-x64" \
   FLAGS="-march=nehalem" \
+  RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" \
   MESON="--cross-file=/root/meson.ini"
 
 COPY Toolchain.cmake /root/


### PR DESCRIPTION
Allows use of not-yet-stable flags, reduces binary size by ~200KB

- https://doc.rust-lang.org/beta/unstable-book/compiler-flags/fmt-debug.html
- https://doc.rust-lang.org/beta/unstable-book/compiler-flags/location-detail.html

Note that rust nightly does not appear to work with gcc10 on x64 (as used by the linux-x64 platform).

/cc @kleisauke who might be interested as it's something we'd investigated previously but was not available in rust nightly at that time.

### linux-armv6
```
-rw-r--r-- 1 root root 76483258 Jul  2 14:18 librsvg-2.a
-rwxr-xr-x 1 root root 13877204 Jul  2 14:19 libvips-cpp.so.8.17.0
```
```
-rw-r--r-- 1 root root 75580254 Jul  2 19:52 librsvg-2.a
-rwxr-xr-x 1 root root 13680556 Jul  2 19:53 libvips-cpp.so.8.17.0
```
### linux-arm64v8
```
-rw-r--r-- 1 root root 106437850 Jul  2 14:14 librsvg-2.a
-rwxr-xr-x 1 root root  16958016 Jul  2 14:14 libvips-cpp.so.8.17.0
```
```
-rw-r--r-- 1 root root 104982200 Jul  2 19:48 librsvg-2.a
-rwxr-xr-x 1 root root  16761400 Jul  2 19:49 libvips-cpp.so.8.17.0
```
### linux-ppc64le
```
-rw-r--r-- 1 root root 106008980 Jul  2 14:17 librsvg-2.a
-rwxr-xr-x 1 root root  18268416 Jul  2 14:18 libvips-cpp.so.8.17.0
```
```
-rw-r--r-- 1 root root 105499294 Jul  2 19:51 librsvg-2.a
-rwxr-xr-x 1 root root  17940744 Jul  2 19:52 libvips-cpp.so.8.17.0
```
### linux-s390x
```
-rw-r--r-- 1 root root 96185394 Jul  2 14:16 librsvg-2.a
-rwxr-xr-x 1 root root 16023320 Jul  2 14:17 libvips-cpp.so.8.17.0
```
```
-rw-r--r-- 1 root root 94985946 Jul  2 19:50 librsvg-2.a
-rwxr-xr-x 1 root root 15757088 Jul  2 19:51 libvips-cpp.so.8.17.0
```
### linuxmusl-arm64v8
```
-rw-r--r-- 1 root root 110094128 Jul  2 14:20 librsvg-2.a
-rwxr-xr-x 1 root root  17100680 Jul  2 14:21 libvips-cpp.so.8.17.0
```
```
-rw-r--r-- 1 root root 108651760 Jul  2 19:53 librsvg-2.a
-rwxr-xr-x 1 root root  16871312 Jul  2 19:54 libvips-cpp.so.8.17.0
```
### linuxmusl-x64
```
-rw-r--r-- 1 root root 93765506 Jul  2 14:25 librsvg-2.a
-rwxr-xr-x 1 root root 17236792 Jul  2 14:27 libvips-cpp.so.8.17.0
```
```
-rw-r--r-- 1 root root 92529782 Jul  2 19:59 librsvg-2.a
-rwxr-xr-x 1 root root 16966464 Jul  2 20:01 libvips-cpp.so.8.17.0
```
### darwin-arm64v8
```
-rw-r--r--   1 runner  staff  64015824 Jul  2 14:23 librsvg-2.a
-rwxr-xr-x   1 runner  staff  16218872 Jul  2 14:24 libvips-cpp.8.17.0.dylib
```
```
-rw-r--r--   1 runner  staff  63410024 Jul  2 19:51 librsvg-2.a
-rwxr-xr-x   1 runner  staff  16018856 Jul  2 19:52 libvips-cpp.8.17.0.dylib
```
### darwin-x64
```
-rw-r--r--   1 runner  staff  65048392 Jul  2 14:30 librsvg-2.a
-rwxr-xr-x   1 runner  staff  18319480 Jul  2 14:31 libvips-cpp.8.17.0.dylib
```
```
-rw-r--r--   1 runner  staff  64527016 Jul  2 20:07 librsvg-2.a
-rwxr-xr-x   1 runner  staff  18137504 Jul  2 20:08 libvips-cpp.8.17.0.dylib
```

