### PR TITLE
Linux: avoid using gold as the linker

### DIFF
--- a/platforms/linux-arm64v8/Dockerfile
+++ b/platforms/linux-arm64v8/Dockerfile
@@ -40,7 +40,7 @@ RUN \
   ln -s /usr/bin/gcc10-as /usr/bin/as && \
   ln -s /usr/bin/gcc10-ar /usr/bin/ar && \
   ln -s /usr/bin/gcc10-nm /usr/bin/nm && \
-  ln -s /usr/bin/gcc10-ld /usr/bin/ld && \
+  ln -s /usr/bin/gcc10-ld.bfd /usr/bin/ld && \
   ln -s /usr/bin/gcc10-strip /usr/bin/strip && \
   ln -s /usr/bin/gcc10-ranlib /usr/bin/ranlib && \
   ln -s /usr/bin/gcc10-readelf /usr/bin/readelf && \
@@ -58,8 +58,8 @@ RUN \
 ENV \
   PKG_CONFIG="pkg-config --static" \
   PLATFORM="linux-arm64v8" \
-  FLAGS="-march=armv8-a" \
-  RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" \
+  FLAGS="-march=armv8-a -fuse-ld=bfd" \
+  RUSTFLAGS="-Clink-arg=-fuse-ld=bfd -Zlocation-detail=none -Zfmt-debug=none" \
   MESON="--cross-file=/root/meson.ini"
 
 COPY Toolchain.cmake /root/

--- a/platforms/linux-x64/Dockerfile
+++ b/platforms/linux-x64/Dockerfile
@@ -40,7 +40,7 @@ RUN \
   ln -s /usr/bin/gcc10-g++ /usr/bin/c++ && \
   ln -s /usr/bin/gcc10-ar /usr/bin/ar && \
   ln -s /usr/bin/gcc10-nm /usr/bin/nm && \
-  ln -s /usr/bin/gcc10-ld /usr/bin/ld && \
+  ln -s /usr/bin/gcc10-ld.bfd /usr/bin/ld && \
   ln -s /usr/bin/gcc10-strip /usr/bin/strip && \
   ln -s /usr/bin/gcc10-ranlib /usr/bin/ranlib && \
   ln -s /usr/bin/gcc10-readelf /usr/bin/readelf && \
@@ -56,7 +56,8 @@ RUN \
 ENV \
   PKG_CONFIG="pkg-config --static" \
   PLATFORM="linux-x64" \
-  FLAGS="-march=nehalem" \
+  FLAGS="-march=nehalem -fuse-ld=bfd" \
+  RUSTFLAGS="-Clink-arg=-fuse-ld=bfd" \
   MESON="--cross-file=/root/meson.ini"
 
 COPY Toolchain.cmake /root/


### PR DESCRIPTION
I suspect this might be the reason of the SEGV in https://github.com/lovell/sharp/commit/2cd2f8430a2e64f9c8604a7aea0c0ace88fb03da on linux-arm64v8. It looks like multiple `.init_array` sections are included in the final binary, which probably won't work.

v1.2.0-rc.4:
```console
$ readelf -WS sharp-libvips-linux-arm64v8/lib/libvips-cpp.so.8.17.1 | grep -E '(init_array|gold-version)'
  [22] .init_array       INIT_ARRAY      0000000000f2c918 f1c918 000258 08  WA  0   0  8
  [24] .init_array       INIT_ARRAY      0000000000f9c960 f8c960 000008 08 WAo  0   0  8
  [32] .note.gnu.gold-version NOTE            0000000000000000 ffb844 00001c 00      0   0  4
```

v1.2.0-rc.3:
```console
$ readelf -WS sharp-libvips-linux-arm64v8/lib/libvips-cpp.so.8.17.0 | grep -E '(init_array|gold-version)'
  [22] .init_array       INIT_ARRAY      0000000000f1dd18 f0dd18 0001a8 08  WA  0   0  8
  [31] .note.gnu.gold-version NOTE            0000000000000000 ffb86c 00001c 00      0   0  4
```

This PR:
```console
$ readelf -WS sharp-libvips-linux-arm64v8/lib/libvips-cpp.so.8.17.1 | grep -E '(init_array|gold-version)'
  [19] .init_array       INIT_ARRAY      0000000000ed8c28 ec8c28 000260 08 WAo  0   0  8
```

See also: https://github.com/rust-lang/rust/issues/141748.