### PR TITLE
linux-x64: use rust nightly

### DIFF
--- a/platforms/linux-arm64v8/Dockerfile
+++ b/platforms/linux-arm64v8/Dockerfile
@@ -44,6 +44,8 @@ RUN \
   ln -s /usr/bin/gcc10-strip /usr/bin/strip && \
   ln -s /usr/bin/gcc10-ranlib /usr/bin/ranlib && \
   ln -s /usr/bin/gcc10-readelf /usr/bin/readelf && \
+  ln -sf /usr/bin/gcc10-ld.bfd /usr/bin/gcc10-ld && \
+  rm /usr/bin/gcc10-ld.gold && \
   curl https://sh.rustup.rs -sSf | sh -s -- -y \
     --no-modify-path \
     --profile minimal \
@@ -58,8 +60,8 @@ RUN \
 ENV \
   PKG_CONFIG="pkg-config --static" \
   PLATFORM="linux-arm64v8" \
-  FLAGS="-march=armv8-a -fuse-ld=bfd" \
-  RUSTFLAGS="-Clink-arg=-fuse-ld=bfd -Zlocation-detail=none -Zfmt-debug=none" \
+  FLAGS="-march=armv8-a" \
+  RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" \
   MESON="--cross-file=/root/meson.ini"
 
 COPY Toolchain.cmake /root/

--- a/platforms/linux-x64/Dockerfile
+++ b/platforms/linux-x64/Dockerfile
@@ -44,9 +44,12 @@ RUN \
   ln -s /usr/bin/gcc10-strip /usr/bin/strip && \
   ln -s /usr/bin/gcc10-ranlib /usr/bin/ranlib && \
   ln -s /usr/bin/gcc10-readelf /usr/bin/readelf && \
+  ln -sf /usr/bin/gcc10-ld.bfd /usr/bin/gcc10-ld && \
+  rm /usr/bin/gcc10-ld.gold && \
   curl https://sh.rustup.rs -sSf | sh -s -- -y \
     --no-modify-path \
     --profile minimal \
+    --default-toolchain nightly \
     && \
   cargo install cargo-c --locked && \
   ln -s /usr/bin/cmake3 /usr/bin/cmake && \
@@ -56,8 +59,8 @@ RUN \
 ENV \
   PKG_CONFIG="pkg-config --static" \
   PLATFORM="linux-x64" \
-  FLAGS="-march=nehalem -fuse-ld=bfd" \
-  RUSTFLAGS="-Clink-arg=-fuse-ld=bfd" \
+  FLAGS="-march=nehalem" \
+  RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" \
   MESON="--cross-file=/root/meson.ini"
 
 COPY Toolchain.cmake /root/


### PR DESCRIPTION
Also, forcefully disable gold as the linker, as Rust still seems to emit a warning:
https://github.com/lovell/sharp-libvips/actions/runs/16145634431/job/45563658436#step:4:13810
(though, I think it's safe in that case, since we are building librsvg statically)

Note that we could use `export CARGO_PROFILE_RELEASE_TRIM_PATHS="all"` as a possible follow-up. However, enabling it isn't very straightforward, since `-Ztrim-paths` cannot be added to the `RUSTFLAGS` env variable, see:
https://doc.rust-lang.org/cargo/reference/unstable.html#profile-trim-paths-option