### PR TITLE
mozjpeg: default to fastest compression profile

### DIFF
--- a/build/posix.sh
+++ b/build/posix.sh
@@ -197,6 +197,8 @@ make install/strip
 mkdir ${DEPS}/jpeg
 $CURL https://github.com/mozilla/mozjpeg/archive/${VERSION_MOZJPEG}.tar.gz | tar xzC ${DEPS}/jpeg --strip-components=1
 cd ${DEPS}/jpeg
+# Use libjpeg-turbo behaviour by default
+sed -i'.bak' 's/JCP_MAX_COMPRESSION/JCP_FASTEST/' jcapimin.c
 cmake -G"Unix Makefiles" \
   -DCMAKE_TOOLCHAIN_FILE=${ROOT}/Toolchain.cmake -DCMAKE_INSTALL_PREFIX=${TARGET} -DCMAKE_INSTALL_LIBDIR:PATH=lib -DCMAKE_BUILD_TYPE=MinSizeRel \
   -DBUILD_SHARED_LIBS=FALSE -DWITH_JPEG8=1 -DWITH_TURBOJPEG=FALSE -DPNG_SUPPORTED=FALSE


### PR DESCRIPTION
In the prebuilt binaries, libultrahdr wraps mozjpeg (via the libjpeg API) but does not expose any of the underlying settings, so gainmap generation is ~3x slower than expected due to use of the default compression profile.

This change matches the [default behaviour](https://github.com/libvips/libvips/blob/36fe7461e07f71107a9108e5778eec81ce00fe73/libvips/foreign/vips2jpeg.c#L582) of libvips.

/cc @kleisauke as you might be interested in this for wasm-vips etc.