### PR TITLE
linuxmusl-arm64v8: explicitly specify linux/arm64 platform

### DIFF
--- a/platforms/linuxmusl-arm64v8/Dockerfile
+++ b/platforms/linuxmusl-arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM --platform=linux/arm64 alpine:3.15
 LABEL maintainer="Lovell Fuller <npm@lovell.info>"
 
 # Create Alpine 3.15 (musl 1.2.2) container suitable for building musl-based Linux ARM64v8-A binaries

--- a/platforms/linuxmusl-x64/Dockerfile
+++ b/platforms/linuxmusl-x64/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15
 LABEL maintainer="Lovell Fuller <npm@lovell.info>"
 
-# Create Alpine 3.15 (musl 1.2.2) container suitable for building Linux x64 binaries
+# Create Alpine 3.15 (musl 1.2.2) container suitable for building musl-based Linux x64 binaries
 
 # Path settings
 ENV \


### PR DESCRIPTION
This clarifies that the arm64 musl binaries are built natively rather than cross-compiled, and makes testing on x64 hosts via QEMU easier.