### PR TITLE
heif: prefer release tarball

### DIFF
--- a/build/posix.sh
+++ b/build/posix.sh
@@ -187,7 +187,7 @@ AOM_AS_FLAGS="${FLAGS}" cmake -G"Unix Makefiles" \
 make install/strip
 
 mkdir ${DEPS}/heif
-$CURL https://github.com/strukturag/libheif/archive/v${VERSION_HEIF}.tar.gz | tar xzC ${DEPS}/heif --strip-components=1
+$CURL https://github.com/strukturag/libheif/releases/download/v${VERSION_HEIF}/libheif-${VERSION_HEIF}.tar.gz | tar xzC ${DEPS}/heif --strip-components=1
 cd ${DEPS}/heif
 CFLAGS="${CFLAGS} -O3" CXXFLAGS="${CXXFLAGS} -O3" cmake -G"Unix Makefiles" \
   -DCMAKE_TOOLCHAIN_FILE=${ROOT}/Toolchain.cmake -DCMAKE_INSTALL_PREFIX=${TARGET} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
i.e. as it was done prior to commit 50386f842dd5188e418c466218a7319bf5d4a0e8.